### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Tested on Python 3.10
 
 ```bash
 cd LiveBench
-pip install torch packaging wheel langdetect # These need to be installed prior to other dependencies.
+pip install torch packaging # These need to be installed prior to other dependencies.
 pip install -e .
 ```
 Note: The fastchat package version on pip is currently out of date and so we strongly recommend `pip uninstall fastchat` before running the above so that you pick up a more recent commit from the dependencies.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Tested on Python 3.10
 
 ```bash
 cd LiveBench
-pip install torch packaging  # These need to be installed prior to other dependencies.
+pip install torch packaging wheel langdetect # These need to be installed prior to other dependencies.
 pip install -e .
 ```
 Note: The fastchat package version on pip is currently out of date and so we strongly recommend `pip uninstall fastchat` before running the above so that you pick up a more recent commit from the dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = [
-    "accelerate>=0.21", "aiohttp", "anthropic>=0.3", "antlr4-python3-runtime==4.11", "datasets", "fastapi", "flash-attn", "httpx", "immutabledict", "langchain",
+    "accelerate>=0.21", "aiohttp", "anthropic>=0.3", "antlr4-python3-runtime==4.11", "datasets", "fastapi", "flash-attn", "httpx", "immutabledict", "langchain", "langdetect",
     "levenshtein", "lxml", "markdown2[all]", "nh3", "nltk", "numpy", "openai<1", "pandas==2.2.2", "peft", "prompt_toolkit>=3.0.0", "protobuf", "pydantic",
-    "pyext==0.7", "psutil", "ray", "requests", "rich>=10.0.0", "sentencepiece", "shortuuid", "sympy>=1.12", "tiktoken", "torch", "tqdm>=4.62.1", "transformers>=4.31.0", "uvicorn",
+    "pyext==0.7", "psutil", "ray", "requests", "rich>=10.0.0", "sentencepiece", "shortuuid", "sympy>=1.12", "tiktoken", "torch", "tqdm>=4.62.1", "transformers>=4.31.0", "uvicorn", "wheel",
     "fschat@git+https://github.com/lm-sys/FastChat#egg=c5223e34babd24c3f9b08205e6751ea6e42c9684",
 ]
 


### PR DESCRIPTION
added wheel and langdetect for dependencies to be installed

I tried to run this on gpt-4o model and it requires `wheel` to install & `langdetect` is required to run gen_ground_truth_judgment.py