### PR TITLE
updates to LiveBench for usability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist
 #*.json
 !playground/deepspeed_config_s2.json
 !playground/deepspeed_config_s3.json
+*.jsonl
 
 # Editor
 .idea

--- a/livebench/download_leaderboard.py
+++ b/livebench/download_leaderboard.py
@@ -10,19 +10,43 @@ from livebench.common import (
 
 model_answer, model_judgment = load_answers_judgments()
 
-for dir_name, file_name, dataset in [
-    ('leaderboard_model_answer', 'all_model_answers.jsonl', model_answer),
-    ('leaderboard_model_judgment', 'all_model_judgments.jsonl', model_judgment)
+for dir_name, dataset in [
+    ('model_answer', model_answer),
+    ('model_judgment', model_judgment)
 ]:
 
     categories, tasks = get_categories_tasks(LIVE_BENCH_DATA_SUPER_PATH)
 
     for category_name, task_names in tqdm(tasks.items()):
         rows = dataset[category_name]
-        category_path = f"data/{LIVE_BENCH_DATA_SUPER_PATH}/{category_name}/{dir_name}"
-        file_path = f"{category_path}/{file_name}"
+        for task_name in task_names:
+            rows_task = [
+                r for r in rows if r['task'] == task_name
+            ]
+            if dir_name == 'model_judgment':
 
-        os.makedirs(category_path, exist_ok=True)
-        with open(file_path, 'w') as f:
-            f.writelines([json.dumps(row, default=str) + '\n' for row in rows])
+                task_path = f"data/{LIVE_BENCH_DATA_SUPER_PATH}/{category_name}/{task_name}/{dir_name}"
+                file_path = f"{task_path}/ground_truth_judgment.jsonl"
 
+                os.makedirs(task_path, exist_ok=True)
+                with open(file_path, 'w') as f:
+                    f.writelines([json.dumps(row, default=str) + '\n' for row in rows_task])
+
+            else:
+                models = set(
+                    [
+                        row['model_id'] for row in rows_task
+                    ]
+                )
+
+                for model in models:
+                    rows_model = [
+                        r for r in rows_task if r['model_id'] == model
+                    ]
+
+                    task_path = f"data/{LIVE_BENCH_DATA_SUPER_PATH}/{category_name}/{task_name}/{dir_name}"
+                    file_path = f"{task_path}/{model}.jsonl"
+
+                    os.makedirs(task_path, exist_ok=True)
+                    with open(file_path, 'w') as f:
+                        f.writelines([json.dumps(row, default=str) + '\n' for row in rows_model])

--- a/livebench/process_results/instruction_following/utils.py
+++ b/livebench/process_results/instruction_following/utils.py
@@ -18,9 +18,9 @@ def score_results(follow_all_instructions, follow_instruction_list, threshold=0.
     return avg_score
 
 
-def instruction_following_process_results(prompt_path: str, llm_answer_path: str, task: str, model_id: str) -> int:
+def instruction_following_process_results(questions, model_answers, task: str, model_id: str) -> int:
     result_log_dir = f"data/live_bench/instruction_following/{task}/model_judgment"
-    results = evaluation_main.evaluator(prompt_path, llm_answer_path, result_log_dir, model_id)
+    results = evaluation_main.evaluator(questions, model_answers, result_log_dir, model_id)
     results = results["strict"] # or "loose" depending on what we want to use.
     scores = []
     for result in results:

--- a/livebench/show_livebench_result.py
+++ b/livebench/show_livebench_result.py
@@ -16,7 +16,7 @@ def display_result_single(args):
         input_files = args.input_file
 
     df_all = pd.concat((pd.read_json(f, lines=True) for f in input_files), ignore_index=True)
-    df = df_all[["model", "score", "category", "grouping"]]
+    df = df_all[["model", "score", "task", "category"]]
     df = df[df["score"] != -1]
     df['model'] = df['model'].str.lower()
     df["score"] *= 100
@@ -24,25 +24,18 @@ def display_result_single(args):
     if args.model_list is not None:
         df = df[df["model"].isin([x.lower() for x in args.model_list])]
 
-    df.loc[df['category'].str.contains('amps_hard_'), 'category'] = 'AMPS_Hard'
-    df.loc[df['category'].str.contains('aime_'), 'category'] = 'math_comp'
-    df.loc[df['category'].str.contains('amc_'), 'category'] = 'math_comp'
-    df.loc[df['category'] == 'smc', 'category'] = 'math_comp'
-    df.loc[df['category'].isin(['usamo', 'imo']), 'category'] = 'olympiad'
-
-
     print("\n########## All Tasks ##########")
-    df_1 = df[["model", "score", "category"]]
-    df_1 = df_1.groupby(["model", "category"]).mean()
-    df_1 = pd.pivot_table(df_1, index=['model'], values = "score", columns=["category"], aggfunc="sum")
+    df_1 = df[["model", "score", "task"]]
+    df_1 = df_1.groupby(["model", "task"]).mean()
+    df_1 = pd.pivot_table(df_1, index=['model'], values = "score", columns=["task"], aggfunc="sum")
     df_1 = df_1.round(3)
     print(df_1.sort_values(by="model"))
     df_1.to_csv('all_tasks.csv')
 
     print("\n########## All Groups ##########")
-    df_1 = df[["model", "score", "grouping", "category"]]
-    df_1 = df_1.groupby(["model", "category", "grouping"]).mean().groupby(["model","grouping"]).mean()
-    df_1 = pd.pivot_table(df_1, index=['model'], values = "score", columns=["grouping"], aggfunc="sum")
+    df_1 = df[["model", "score", "category", "task"]]
+    df_1 = df_1.groupby(["model", "task", "category"]).mean().groupby(["model","category"]).mean()
+    df_1 = pd.pivot_table(df_1, index=['model'], values = "score", columns=["category"], aggfunc="sum")
 
     df_1['average'] = df_1.mean(axis=1)
     first_col = df_1.pop('average')


### PR DESCRIPTION
update to LiveBench to:
- unify the nomenclature of "category" (a meta-group of which at this time there are 6) and "task" (a specific type of questions, of which at this time there are 18). this includes removing the `grouping` key from various files (which was done to hf datasets)
- improve the `download_leaderboard.py` script to separate each model's answers into its own jsonl file per task
  - update the processing of `instruction_following` tasks in order to manage this change (updates to `livebench/lf_runner/instruction_following_eval/evaluation_main.py` and `livebench/process_results/instruction_following/utils.py
- permit trailing `/` when running a command like `python gen_ground_truth_judgment.py --bench-name live_bench/`