### PR TITLE
renamed show_livebench_result.py to show_livebench_results.py

### DIFF
--- a/livebench/show_livebench_results.py
+++ b/livebench/show_livebench_results.py
@@ -1,6 +1,6 @@
 """
 Usage:
-python3 show_livebench_result.py
+python3 show_livebench_results.py
 """
 import argparse
 import pandas as pd


### PR DESCRIPTION
The documentation mentions `show_livebench_results.py`, but the script is actually named `show_livebench_result.py` in the main branch. This PR renames the script to match what's in the documentation, making it a bit easier to find and use.