### PR TITLE
Implement Python 3.11 and 3.12 compatibility

### DIFF
--- a/livebench/gen_ground_truth_judgment.py
+++ b/livebench/gen_ground_truth_judgment.py
@@ -88,7 +88,7 @@ def play_a_match_gt(match: MatchSingle, output_file: str, debug=False):
     question_text = question["turns"][0]
     ground_truth = question.get("ground_truth", None)
     llm_answer = answer['choices'][0]['turns'][-1]
-    llm_answer = re.sub(f"<think>.*?<\/think>", "", llm_answer, flags=re.DOTALL)
+    llm_answer = re.sub(r"<think>.*?<\/think>", "", llm_answer, flags=re.DOTALL)
     score = 0
     category = None
 
@@ -261,7 +261,7 @@ def gen_judgments(
 
         for m in model_answers:
             for q in model_answers[m]:
-                model_answers[m][q]['choices'][0]['turns'][0] = re.sub(f"<think>.*?<\/think>", "", model_answers[m][q]['choices'][0]['turns'][0], flags=re.DOTALL).strip()
+                model_answers[m][q]['choices'][0]['turns'][0] = re.sub(r"<think>.*?<\/think>", "", model_answers[m][q]['choices'][0]['turns'][0], flags=re.DOTALL).strip()
 
         for model_id in models:
             scores = instruction_following_process_results(questions, model_answers, task_name, model_id, debug)

--- a/livebench/lcb_runner/evaluation/testing_util.py
+++ b/livebench/lcb_runner/evaluation/testing_util.py
@@ -110,275 +110,229 @@ def run_test(sample, test=None, debug=False, timeout=6):
     otherwise it'll just return an input and output pair.
     """
     # Disable functionalities that can make destructive changes to the test.
-    reliability_guard()
-
-    if debug:
-        print(f"start = {datetime.now().time()}")
-
-    try:
-        in_outs = json.loads(sample["input_output"])
-    except ValueError:
-        in_outs = None
-    if in_outs:
-        if in_outs.get("fn_name") is None:
-            which_type = CODE_TYPE.standard_input  # Standard input
-            method_name = None
-        else:
-            which_type = CODE_TYPE.call_based  # Call-based
-            method_name = in_outs["fn_name"]
-
-    if debug:
-        print(f"loaded input_output = {datetime.now().time()}")
-
-    if test is None:
-        assert False, "should not happen: test code is none"
-        return in_outs, {"error": "no test code provided"}
-    elif test is not None:
-        results = []
-        sol = "from string import *\nfrom re import *\nfrom datetime import *\nfrom collections import *\nfrom heapq import *\nfrom bisect import *\nfrom copy import *\nfrom math import *\nfrom random import *\nfrom statistics import *\nfrom itertools import *\nfrom functools import *\nfrom operator import *\nfrom io import *\nfrom sys import *\nfrom json import *\nfrom builtins import *\nfrom typing import *\nimport string\nimport re\nimport datetime\nimport collections\nimport heapq\nimport bisect\nimport copy\nimport math\nimport random\nimport statistics\nimport itertools\nimport functools\nimport operator\nimport io\nimport sys\nimport json\nsys.setrecursionlimit(6*10**5)\n"
+    with ReliabilityGuard(maximum_memory_bytes=None) as _guard:
         if debug:
-            print(f"loading test code = {datetime.now().time()}")
-
-        if which_type == CODE_TYPE.call_based:
-
-            sol += test
-            if debug:
-                print(f"sol = {sol}")
-            signal.alarm(timeout)
-            try:
-                tmp_sol = RuntimeModule.from_string("tmp_sol", "", sol)
-                if "class Solution" not in test:
-                    tmp = tmp_sol
-                else:
-                    tmp = tmp_sol.Solution()
-                signal.alarm(0)
-            except Exception as e:
-                signal.alarm(0)
-                if debug:
-                    print(f"type 0 compilation error = {e}")
-                results.append(-2)
-                return results, {
-                    "error": repr(e),
-                    "error_code": -1,
-                    "error_message": "Compilation Error",
-                }
-            signal.alarm(0)
-
-        elif which_type == CODE_TYPE.standard_input:
-            # sol
-            # if code has if __name__ == "__main__": then remove it
-            try:
-                astree = ast.parse(test)
-                last_block = astree.body[-1]
-                if isinstance(last_block, ast.If):
-                    condition = last_block.test
-                    if ast.unparse(condition).strip() == "__name__ == '__main__'":
-                        test = (
-                            ast.unparse(astree.body[:-1])
-                            + "\n"
-                            + ast.unparse(last_block.body)
-                        )
-            except:
-                pass
-
-            tmp_test = test.split("\n")
-
-            new_test = []
-            for x in tmp_test:
-                if (not x.startswith("from ")) and (not x.startswith("import ")):
-                    new_test.append("\t" + x + "\n")
-                else:
-                    new_test.append(x + "\n")
-            tmp_test = new_test
-
-            new_test = ""
-            started = False
-            for i in tmp_test:
-                if i.startswith("\t") and not started:
-                    new_test += "stdin = sys.stdin\nstdout = sys.stdout\n"
-                    new_test += "def code():\n"
-                    new_test += i
-                    started = True
-                elif started and ((i.startswith("from ")) or (i.startswith("import "))):
-                    new_test += "\t" + i
-                else:
-                    new_test += i
-            tmp_test = new_test
-
-            sol += tmp_test
-            if debug:
-                print(f"sol = {sol}")
-            method_name = "code"
-            signal.alarm(timeout)
-            try:
-                tmp_sol = RuntimeModule.from_string("tmp_sol", "", sol)
-                tmp = tmp_sol
-                signal.alarm(0)
-            except Exception as e:
-                signal.alarm(0)
-                if debug:
-                    print(f"type 1 compilation error = {e}")
-                results.append(-2)
-                return results, {
-                    "error": repr(e),
-                    "error_code": -1,
-                    "error_message": "Compilation Error",
-                }
-            signal.alarm(0)
-        if debug:
-            print(f"get method = {datetime.now().time()}")
+            print(f"start = {datetime.now().time()}")
 
         try:
-            method = getattr(tmp, method_name)  # get_attr second arg must be str
-        except:
-            signal.alarm(0)
-            e = sys.exc_info()
-            print(f"unable to get function error = {e}")
-            results.append(-2)
-            return results, {
-                "error": repr(e),
-                "error_code": -1,
-                "error_message": "Unable to extract code",
-            }
-
-        for index, inputs in enumerate(in_outs["inputs"]):
-            raw_inputs = inputs
-            raw_outputs = in_outs["outputs"][index]
-            if which_type == CODE_TYPE.call_based:
-                inputs = [json.loads(line) for line in inputs.split("\n")]
-                in_outs["outputs"][index] = json.loads(in_outs["outputs"][index])
-
-                truncate_line_size = 300 // (raw_inputs.count("\n") + 1)
-                raw_inputs = "\n".join(
-                    [
-                        truncatefn(line, truncate_line_size)
-                        for line in raw_inputs.strip().split("\n")
-                    ]
-                )
-                raw_outputs = truncatefn(raw_outputs, 200)
+            in_outs = json.loads(sample["input_output"])
+        except ValueError:
+            in_outs = None
+        if in_outs:
+            if in_outs.get("fn_name") is None:
+                which_type = CODE_TYPE.standard_input  # Standard input
+                method_name = None
             else:
-                raw_inputs = truncatefn(raw_inputs)
-                raw_outputs = truncatefn(raw_outputs, 200)
-            # JSON forces dictionaries to have string keys; this undoes this (assuming a singleton list)
-            try:
-                if isinstance(inputs[0], dict):
-                    inputs = [{int(k): v for k, v in inputs[0].items()}]
-            except:
-                True
-            try:
-                if isinstance(in_outs["outputs"][index], dict):
-                    in_outs["outputs"][index] = [
-                        {int(k): v for k, v in in_outs["outputs"][index].items()}
-                    ]
-            except:
-                True
-            try:
-                if isinstance(in_outs["outputs"][index][0], dict):
-                    in_outs["outputs"][index] = [
-                        {int(k): v for k, v in in_outs["outputs"][index][0].items()}
-                    ]
-            except:
-                True
+                which_type = CODE_TYPE.call_based  # Call-based
+                method_name = in_outs["fn_name"]
 
+        if debug:
+            print(f"loaded input_output = {datetime.now().time()}")
+
+        if test is None:
+            assert False, "should not happen: test code is none"
+            return in_outs, {"error": "no test code provided"}
+        elif test is not None:
+            results = []
+            sol = "from string import *\nfrom re import *\nfrom datetime import *\nfrom collections import *\nfrom heapq import *\nfrom bisect import *\nfrom copy import *\nfrom math import *\nfrom random import *\nfrom statistics import *\nfrom itertools import *\nfrom functools import *\nfrom operator import *\nfrom io import *\nfrom sys import *\nfrom json import *\nfrom builtins import *\nfrom typing import *\nimport string\nimport re\nimport datetime\nimport collections\nimport heapq\nimport bisect\nimport copy\nimport math\nimport random\nimport statistics\nimport itertools\nimport functools\nimport operator\nimport io\nimport sys\nimport json\nsys.setrecursionlimit(6*10**5)\n"
             if debug:
-                print(
-                    f"time: {datetime.now().time()} testing index = {index}  inputs = {inputs}, {type(inputs)}. type = {which_type}"
-                )
-            if which_type == CODE_TYPE.call_based:  # Call-based
+                print(f"loading test code = {datetime.now().time()}")
+
+            if which_type == CODE_TYPE.call_based:
+
+                sol += test
+                if debug:
+                    print(f"sol = {sol}")
                 signal.alarm(timeout)
-                faulthandler.enable()
                 try:
-                    output = method(*inputs)
-                    raw_true_output = output
-
-                    raw_true_output_copy = json.dumps(output)
-                    raw_true_output_copy = truncatefn(raw_true_output_copy, 200)
-
-                    # ground truth sequences are not tuples
-                    if isinstance(output, tuple):
-                        output = list(output)
-
-                    tmp_result = output == in_outs["outputs"][index]
-                    if (
-                        isinstance(in_outs["outputs"][index], list)
-                        and in_outs["outputs"][index]
-                    ):
-                        tmp_result = tmp_result or (
-                            output == in_outs["outputs"][index][0]
-                        )
-
-                    # ground truth sequences are not tuples
-                    try:
-                        if isinstance(output[0], tuple):
-                            tmp_result = tmp_result or (
-                                [list(x) for x in output]
-                                == in_outs["outputs"][index][0]
-                            )
-                    except:
-                        True
-                    results.append(tmp_result)
-                    if tmp_result != True:
-                        return results, {
-                            "output": raw_true_output_copy,
-                            "expected": raw_outputs,
-                            "inputs": raw_inputs,
-                            "error_code": -2,
-                            "error_message": "Wrong Answer",
-                        }
-                    # reset the alarm
+                    tmp_sol = RuntimeModule.from_string("tmp_sol", "", sol)
+                    if "class Solution" not in test:
+                        tmp = tmp_sol
+                    else:
+                        tmp = tmp_sol.Solution()
                     signal.alarm(0)
                 except Exception as e:
                     signal.alarm(0)
-                    faulthandler.disable()
                     if debug:
-                        print(
-                            f"Standard input runtime error or time limit exceeded error = {e}"
-                        )
-                    results.append(-1)
-                    if "timeoutexception" in repr(e).lower():
-                        return results, {
-                            "error": repr(e),
-                            "error_code": -3,
-                            "error_message": "Time Limit Exceeded",
-                            "inputs": raw_inputs,
-                            "expected": raw_outputs,
-                        }
-                    else:
-                        return results, {
-                            "error": repr(e),
-                            "error_code": -4,
-                            "error_message": "Runtime Error",
-                            "inputs": raw_inputs,
-                            "expected": raw_outputs,
-                        }
-                faulthandler.disable()
+                        print(f"type 0 compilation error = {e}")
+                    results.append(-2)
+                    return results, {
+                        "error": repr(e),
+                        "error_code": -1,
+                        "error_message": "Compilation Error",
+                    }
                 signal.alarm(0)
+
+            elif which_type == CODE_TYPE.standard_input:
+                # sol
+                # if code has if __name__ == "__main__": then remove it
+                try:
+                    astree = ast.parse(test)
+                    last_block = astree.body[-1]
+                    if isinstance(last_block, ast.If):
+                        condition = last_block.test
+                        if ast.unparse(condition).strip() == "__name__ == '__main__'":
+                            test = (
+                                ast.unparse(astree.body[:-1])
+                                + "\n"
+                                + ast.unparse(last_block.body)
+                            )
+                except:
+                    pass
+
+                tmp_test = test.split("\n")
+
+                new_test = []
+                for x in tmp_test:
+                    if (not x.startswith("from ")) and (not x.startswith("import ")):
+                        new_test.append("\t" + x + "\n")
+                    else:
+                        new_test.append(x + "\n")
+                tmp_test = new_test
+
+                new_test = ""
+                started = False
+                for i in tmp_test:
+                    if i.startswith("\t") and not started:
+                        new_test += "stdin = sys.stdin\nstdout = sys.stdout\n"
+                        new_test += "def code():\n"
+                        new_test += i
+                        started = True
+                    elif started and ((i.startswith("from ")) or (i.startswith("import "))):
+                        new_test += "\t" + i
+                    else:
+                        new_test += i
+                tmp_test = new_test
+
+                sol += tmp_test
+                if debug:
+                    print(f"sol = {sol}")
+                method_name = "code"
+                signal.alarm(timeout)
+                try:
+                    tmp_sol = RuntimeModule.from_string("tmp_sol", "", sol)
+                    tmp = tmp_sol
+                    signal.alarm(0)
+                except Exception as e:
+                    signal.alarm(0)
+                    if debug:
+                        print(f"type 1 compilation error = {e}")
+                    results.append(-2)
+                    return results, {
+                        "error": repr(e),
+                        "error_code": -1,
+                        "error_message": "Compilation Error",
+                    }
+                signal.alarm(0)
+            if debug:
+                print(f"get method = {datetime.now().time()}")
+
+            try:
+                method = getattr(tmp, method_name)  # get_attr second arg must be str
+            except:
+                signal.alarm(0)
+                e = sys.exc_info()
+                print(f"unable to get function error = {e}")
+                results.append(-2)
+                return results, {
+                    "error": repr(e),
+                    "error_code": -1,
+                    "error_message": "Unable to extract code",
+                }
+
+            for index, inputs in enumerate(in_outs["inputs"]):
+                raw_inputs = inputs
+                raw_outputs = in_outs["outputs"][index]
+                if which_type == CODE_TYPE.call_based:
+                    inputs = [json.loads(line) for line in inputs.split("\n")]
+                    in_outs["outputs"][index] = json.loads(in_outs["outputs"][index])
+
+                    truncate_line_size = 300 // (raw_inputs.count("\n") + 1)
+                    raw_inputs = "\n".join(
+                        [
+                            truncatefn(line, truncate_line_size)
+                            for line in raw_inputs.strip().split("\n")
+                        ]
+                    )
+                    raw_outputs = truncatefn(raw_outputs, 200)
+                else:
+                    raw_inputs = truncatefn(raw_inputs)
+                    raw_outputs = truncatefn(raw_outputs, 200)
+                # JSON forces dictionaries to have string keys; this undoes this (assuming a singleton list)
+                try:
+                    if isinstance(inputs[0], dict):
+                        inputs = [{int(k): v for k, v in inputs[0].items()}]
+                except:
+                    True
+                try:
+                    if isinstance(in_outs["outputs"][index], dict):
+                        in_outs["outputs"][index] = [
+                            {int(k): v for k, v in in_outs["outputs"][index].items()}
+                        ]
+                except:
+                    True
+                try:
+                    if isinstance(in_outs["outputs"][index][0], dict):
+                        in_outs["outputs"][index] = [
+                            {int(k): v for k, v in in_outs["outputs"][index][0].items()}
+                        ]
+                except:
+                    True
+
                 if debug:
                     print(
-                        f"outputs = {output}, test outputs = {in_outs['outputs'][index]}, inputs = {inputs}, {type(inputs)}, {output == [in_outs['outputs'][index]]}"
+                        f"time: {datetime.now().time()} testing index = {index}  inputs = {inputs}, {type(inputs)}. type = {which_type}"
                     )
-            elif which_type == CODE_TYPE.standard_input:  # Standard input
-                faulthandler.enable()
-                passed = False
-
-                if isinstance(inputs, list):
-                    inputs = "\n".join(inputs)
-                if isinstance(in_outs["outputs"][index], list):
-                    in_outs["outputs"][index] = "\n".join(in_outs["outputs"][index])
-
-                signal.alarm(timeout)
-                with Capturing() as output:
+                if which_type == CODE_TYPE.call_based:  # Call-based
+                    signal.alarm(timeout)
+                    faulthandler.enable()
                     try:
-                        call_method(method, inputs)
+                        output = method(*inputs)
+                        raw_true_output = output
+
+                        raw_true_output_copy = json.dumps(output)
+                        raw_true_output_copy = truncatefn(raw_true_output_copy, 200)
+
+                        # ground truth sequences are not tuples
+                        if isinstance(output, tuple):
+                            output = list(output)
+
+                        tmp_result = output == in_outs["outputs"][index]
+                        if (
+                            isinstance(in_outs["outputs"][index], list)
+                            and in_outs["outputs"][index]
+                        ):
+                            tmp_result = tmp_result or (
+                                output == in_outs["outputs"][index][0]
+                            )
+
+                        # ground truth sequences are not tuples
+                        try:
+                            if isinstance(output[0], tuple):
+                                tmp_result = tmp_result or (
+                                    [list(x) for x in output]
+                                    == in_outs["outputs"][index][0]
+                                )
+                        except:
+                            True
+                        results.append(tmp_result)
+                        if tmp_result != True:
+                            return results, {
+                                "output": raw_true_output_copy,
+                                "expected": raw_outputs,
+                                "inputs": raw_inputs,
+                                "error_code": -2,
+                                "error_message": "Wrong Answer",
+                            }
                         # reset the alarm
                         signal.alarm(0)
-                        passed = True
                     except Exception as e:
-                        # runtime error or took too long
                         signal.alarm(0)
-                        print(
-                            f"Call-based runtime error or time limit exceeded error = {repr(e)}{e}"
-                        )
+                        faulthandler.disable()
+                        if debug:
+                            print(
+                                f"Standard input runtime error or time limit exceeded error = {e}"
+                            )
                         results.append(-1)
                         if "timeoutexception" in repr(e).lower():
                             return results, {
@@ -396,256 +350,301 @@ def run_test(sample, test=None, debug=False, timeout=6):
                                 "inputs": raw_inputs,
                                 "expected": raw_outputs,
                             }
+                    faulthandler.disable()
                     signal.alarm(0)
-                raw_true_output = output[0]
-                raw_true_output_copy = truncatefn(raw_true_output, 200)
-                output = raw_true_output.splitlines()
-                if not passed:
+                    if debug:
+                        print(
+                            f"outputs = {output}, test outputs = {in_outs['outputs'][index]}, inputs = {inputs}, {type(inputs)}, {output == [in_outs['outputs'][index]]}"
+                        )
+                elif which_type == CODE_TYPE.standard_input:  # Standard input
+                    faulthandler.enable()
+                    passed = False
+
+                    if isinstance(inputs, list):
+                        inputs = "\n".join(inputs)
+                    if isinstance(in_outs["outputs"][index], list):
+                        in_outs["outputs"][index] = "\n".join(in_outs["outputs"][index])
+
+                    signal.alarm(timeout)
+                    with Capturing() as output:
+                        try:
+                            call_method(method, inputs)
+                            # reset the alarm
+                            signal.alarm(0)
+                            passed = True
+                        except Exception as e:
+                            # runtime error or took too long
+                            signal.alarm(0)
+                            print(
+                                f"Call-based runtime error or time limit exceeded error = {repr(e)}{e}"
+                            )
+                            results.append(-1)
+                            if "timeoutexception" in repr(e).lower():
+                                return results, {
+                                    "error": repr(e),
+                                    "error_code": -3,
+                                    "error_message": "Time Limit Exceeded",
+                                    "inputs": raw_inputs,
+                                    "expected": raw_outputs,
+                                }
+                            else:
+                                return results, {
+                                    "error": repr(e),
+                                    "error_code": -4,
+                                    "error_message": "Runtime Error",
+                                    "inputs": raw_inputs,
+                                    "expected": raw_outputs,
+                                }
+                        signal.alarm(0)
+                    raw_true_output = output[0]
+                    raw_true_output_copy = truncatefn(raw_true_output, 200)
+                    output = raw_true_output.splitlines()
+                    if not passed:
+                        if debug:
+                            nl = "\n"
+                            if not isinstance(inputs, list):
+                                print(
+                                    f"not passed output = {output}, test outputs = {in_outs['outputs'][index]}, inputs = {inputs.replace(nl,' new-line ')}, {type(inputs)}, {output == [in_outs['outputs'][index]]}"
+                                )
+                            else:
+                                print(
+                                    f"not passed output = {output}, test outputs = {in_outs['outputs'][index]}, inputs = {inputs}, {type(inputs)}, {output == [in_outs['outputs'][index]]}"
+                                )
+                        continue
+
+                    if passed and debug:
+                        print(
+                            f"==> output = {output}, test outputs = {in_outs['outputs'][index]}"
+                        )
+
+                    if custom_compare_(output, in_outs["outputs"][index]):
+                        tmp_result = True
+                        results.append(tmp_result)
+                        continue
+
+                    # ground truth sequences are expressed as lists not tuples
+                    if isinstance(output, tuple):
+                        output = list(output)
+
+                    tmp_result = False
+                    try:
+                        tmp_result = output == [in_outs["outputs"][index]]
+                        if isinstance(in_outs["outputs"][index], list):
+                            tmp_result = tmp_result or (output == in_outs["outputs"][index])
+                            if isinstance(output[0], str):
+                                tmp_result = tmp_result or (
+                                    [e.strip() for e in output] == in_outs["outputs"][index]
+                                )
+                    except Exception as e:
+                        if debug:
+                            print(f"Failed check1 exception = {e}")
+                        pass
+
+                    if tmp_result == True:
+                        results.append(tmp_result)
+                        continue
+
+                    # try one more time without \n
+                    if isinstance(in_outs["outputs"][index], list):
+                        for tmp_index, i in enumerate(in_outs["outputs"][index]):
+                            in_outs["outputs"][index][tmp_index] = i.split("\n")
+                            in_outs["outputs"][index][tmp_index] = [
+                                x.strip() for x in in_outs["outputs"][index][tmp_index] if x
+                            ]
+                    else:
+                        in_outs["outputs"][index] = in_outs["outputs"][index].split("\n")
+                        in_outs["outputs"][index] = list(
+                            filter(len, in_outs["outputs"][index])
+                        )
+                        in_outs["outputs"][index] = list(
+                            map(lambda x: x.strip(), in_outs["outputs"][index])
+                        )
+
+                    try:
+                        tmp_result = output == [in_outs["outputs"][index]]
+                        if isinstance(in_outs["outputs"][index], list):
+                            tmp_result = tmp_result or (output == in_outs["outputs"][index])
+                    except Exception as e:
+                        if debug:
+                            print(f"Failed check2 exception = {e}")
+                        pass
+
+                    if tmp_result == True:
+                        results.append(tmp_result)
+                        continue
+
+                    # try by converting the output into a split up list too
+                    if isinstance(output, list):
+                        output = list(filter(len, output))
+
                     if debug:
                         nl = "\n"
                         if not isinstance(inputs, list):
                             print(
-                                f"not passed output = {output}, test outputs = {in_outs['outputs'][index]}, inputs = {inputs.replace(nl,' new-line ')}, {type(inputs)}, {output == [in_outs['outputs'][index]]}"
+                                f"@1 output = {output}, test outputs = {in_outs['outputs'][index]}, inputs = {inputs.replace(nl,' new-line ')}, {type(inputs)}, {output == [in_outs['outputs'][index]]} {tmp_result=}"
                             )
                         else:
                             print(
-                                f"not passed output = {output}, test outputs = {in_outs['outputs'][index]}, inputs = {inputs}, {type(inputs)}, {output == [in_outs['outputs'][index]]}"
+                                f"@1 output = {output}, test outputs = {in_outs['outputs'][index]}, inputs = {inputs}, {type(inputs)}, {output == [in_outs['outputs'][index]]} {tmp_result=}"
                             )
-                    continue
 
-                if passed and debug:
-                    print(
-                        f"==> output = {output}, test outputs = {in_outs['outputs'][index]}"
-                    )
+                    if tmp_result == True:
+                        results.append(tmp_result)
+                        continue
 
-                if custom_compare_(output, in_outs["outputs"][index]):
-                    tmp_result = True
-                    results.append(tmp_result)
-                    continue
-
-                # ground truth sequences are expressed as lists not tuples
-                if isinstance(output, tuple):
-                    output = list(output)
-
-                tmp_result = False
-                try:
-                    tmp_result = output == [in_outs["outputs"][index]]
-                    if isinstance(in_outs["outputs"][index], list):
-                        tmp_result = tmp_result or (output == in_outs["outputs"][index])
-                        if isinstance(output[0], str):
-                            tmp_result = tmp_result or (
-                                [e.strip() for e in output] == in_outs["outputs"][index]
-                            )
-                except Exception as e:
                     if debug:
-                        print(f"Failed check1 exception = {e}")
-                    pass
+                        print(f"{tmp_result=} @a")
 
-                if tmp_result == True:
-                    results.append(tmp_result)
-                    continue
-
-                # try one more time without \n
-                if isinstance(in_outs["outputs"][index], list):
-                    for tmp_index, i in enumerate(in_outs["outputs"][index]):
-                        in_outs["outputs"][index][tmp_index] = i.split("\n")
-                        in_outs["outputs"][index][tmp_index] = [
-                            x.strip() for x in in_outs["outputs"][index][tmp_index] if x
-                        ]
-                else:
-                    in_outs["outputs"][index] = in_outs["outputs"][index].split("\n")
-                    in_outs["outputs"][index] = list(
-                        filter(len, in_outs["outputs"][index])
-                    )
-                    in_outs["outputs"][index] = list(
-                        map(lambda x: x.strip(), in_outs["outputs"][index])
-                    )
-
-                try:
-                    tmp_result = output == [in_outs["outputs"][index]]
-                    if isinstance(in_outs["outputs"][index], list):
-                        tmp_result = tmp_result or (output == in_outs["outputs"][index])
-                except Exception as e:
-                    if debug:
-                        print(f"Failed check2 exception = {e}")
-                    pass
-
-                if tmp_result == True:
-                    results.append(tmp_result)
-                    continue
-
-                # try by converting the output into a split up list too
-                if isinstance(output, list):
-                    output = list(filter(len, output))
-
-                if debug:
-                    nl = "\n"
-                    if not isinstance(inputs, list):
-                        print(
-                            f"@1 output = {output}, test outputs = {in_outs['outputs'][index]}, inputs = {inputs.replace(nl,' new-line ')}, {type(inputs)}, {output == [in_outs['outputs'][index]]} {tmp_result=}"
-                        )
-                    else:
-                        print(
-                            f"@1 output = {output}, test outputs = {in_outs['outputs'][index]}, inputs = {inputs}, {type(inputs)}, {output == [in_outs['outputs'][index]]} {tmp_result=}"
-                        )
-
-                if tmp_result == True:
-                    results.append(tmp_result)
-                    continue
-
-                if debug:
-                    print(f"{tmp_result=} @a")
-
-                try:
-                    tmp_result = output == [in_outs["outputs"][index]]
-                    if isinstance(in_outs["outputs"][index], list):
-                        tmp_result = tmp_result or (output == in_outs["outputs"][index])
-                except Exception as e:
-                    if debug:
-                        print(f"Failed check3 exception = {e}")
-                    pass
-
-                if debug:
-                    print(f"{tmp_result=} @b")
-
-                try:
-                    all_ints = all(
-                        combined_int_check(e1) and combined_int_check(e2)
-                        for e1, e2 in zip(output, in_outs["outputs"][index])
-                    )
-                    if not all_ints:
+                    try:
+                        tmp_result = output == [in_outs["outputs"][index]]
+                        if isinstance(in_outs["outputs"][index], list):
+                            tmp_result = tmp_result or (output == in_outs["outputs"][index])
+                    except Exception as e:
                         if debug:
-                            print(
-                                [
-                                    combined_int_check(e1) and combined_int_check(e2)
-                                    for e1, e2 in zip(output, in_outs["outputs"][index])
-                                ]
-                            )
-                        output_float = [float(e) for e in output]
-                        gt_float = [float(e) for e in in_outs["outputs"][index]]
-                        tmp_result = tmp_result or (
-                            (len(output_float) == len(gt_float))
-                            and np.allclose(output_float, gt_float)
-                        )
-                except Exception as e:
-                    pass
+                            print(f"Failed check3 exception = {e}")
+                        pass
 
-                if debug:
-                    print(f"{tmp_result=} @c")
+                    if debug:
+                        print(f"{tmp_result=} @b")
 
-                try:
-                    if isinstance(output[0], list):
+                    try:
                         all_ints = all(
                             combined_int_check(e1) and combined_int_check(e2)
-                            for e1, e2 in zip(output[0], in_outs["outputs"][index])
+                            for e1, e2 in zip(output, in_outs["outputs"][index])
                         )
                         if not all_ints:
-                            output_float = [float(e) for e in output[0]]
-                            gt_float = [float(e) for e in in_outs["outputs"][index][0]]
+                            if debug:
+                                print(
+                                    [
+                                        combined_int_check(e1) and combined_int_check(e2)
+                                        for e1, e2 in zip(output, in_outs["outputs"][index])
+                                    ]
+                                )
+                            output_float = [float(e) for e in output]
+                            gt_float = [float(e) for e in in_outs["outputs"][index]]
                             tmp_result = tmp_result or (
                                 (len(output_float) == len(gt_float))
                                 and np.allclose(output_float, gt_float)
                             )
-                except Exception as e:
-                    pass
+                    except Exception as e:
+                        pass
 
-                if tmp_result == True:
-                    results.append(tmp_result)
-                    continue
-
-                if debug:
-                    print(f"{tmp_result=} @d")
-                # try by converting the stuff into split up list
-                if isinstance(in_outs["outputs"][index], list):
-                    for tmp_index, i in enumerate(in_outs["outputs"][index]):
-                        in_outs["outputs"][index][tmp_index] = set(i.split())
-                else:
-                    in_outs["outputs"][index] = set(in_outs["outputs"][index].split())
-
-                if debug:
-                    print(f"{tmp_result=} @e")
-
-                try:
-                    tmp_result = output == in_outs["outputs"][index]
-                except Exception as e:
                     if debug:
-                        print(f"Failed check4 exception = {e}")
-                    continue
+                        print(f"{tmp_result=} @c")
 
-                if tmp_result == True:
-                    results.append(tmp_result)
-                    continue
+                    try:
+                        if isinstance(output[0], list):
+                            all_ints = all(
+                                combined_int_check(e1) and combined_int_check(e2)
+                                for e1, e2 in zip(output[0], in_outs["outputs"][index])
+                            )
+                            if not all_ints:
+                                output_float = [float(e) for e in output[0]]
+                                gt_float = [float(e) for e in in_outs["outputs"][index][0]]
+                                tmp_result = tmp_result or (
+                                    (len(output_float) == len(gt_float))
+                                    and np.allclose(output_float, gt_float)
+                                )
+                    except Exception as e:
+                        pass
 
-                if debug:
-                    print(f"{tmp_result=} @f")
+                    if tmp_result == True:
+                        results.append(tmp_result)
+                        continue
 
-                # try by converting the output into a split up list too
-                if isinstance(output, list):
-                    for tmp_index, i in enumerate(output):
-                        output[tmp_index] = i.split()
-                    output = list(filter(len, output))
-                    for tmp_index, i in enumerate(output):
-                        output[tmp_index] = set(i)
-                else:
-                    output = output.split()
-                    output = list(filter(len, output))
-                    output = set(output)
-
-                if debug:
-                    print(f"{tmp_result=} @g")
-                # try:
-                #     tmp_result = set(frozenset(s) for s in output) == set(
-                #         frozenset(s) for s in in_outs["outputs"][index]
-                #     )
-                # except Exception as e:
-                #     if debug:
-                #         print(f"Failed check5 exception = {e}")
-
-                # if they are all numbers, round so that similar numbers are treated as identical
-                # try:
-                #     all_ints = all(
-                #         combined_int_check(e1) and combined_int_check(e2)
-                #         for e1, e2 in zip(output, in_outs["outputs"][index])
-                #     )
-                #     tmp_result = tmp_result or (
-                #         set(frozenset(round(float(t), 3) for t in s) for s in output)
-                #         == set(
-                #             frozenset(round(float(t), 3) for t in s)
-                #             for s in in_outs["outputs"][index]
-                #         )
-                #     )
-                # except Exception as e:
-                #     if debug:
-                #         print(f"Failed check6 exception = {e}")
-
-                if debug:
-                    print(f"{tmp_result=} @h")
-
-                if tmp_result == True and debug:
-                    print("PASSED")
-
-                results.append(tmp_result)
-                if tmp_result != True:
-                    return results, {
-                        "output": raw_true_output_copy,
-                        "expected": raw_outputs,
-                        "inputs": raw_inputs,
-                        "error_code": -2,
-                        "error_message": "Wrong Answer",
-                    }
-
-                if debug:
-                    nl = "\n"
-                    if not isinstance(inputs, list):
-                        print(
-                            f"@2 output = {output}, test outputs = {in_outs['outputs'][index]}, inputs = {inputs.replace(nl,' new-line ')}, {type(inputs)}, {output == [in_outs['outputs'][index]]}"
-                        )
+                    if debug:
+                        print(f"{tmp_result=} @d")
+                    # try by converting the stuff into split up list
+                    if isinstance(in_outs["outputs"][index], list):
+                        for tmp_index, i in enumerate(in_outs["outputs"][index]):
+                            in_outs["outputs"][index][tmp_index] = set(i.split())
                     else:
-                        print(
-                            f"@2 output = {output}, test outputs = {in_outs['outputs'][index]}, inputs = {inputs}, {type(inputs)}, {output == [in_outs['outputs'][index]]}"
-                        )
+                        in_outs["outputs"][index] = set(in_outs["outputs"][index].split())
 
-                    print(f"results = {results}")
+                    if debug:
+                        print(f"{tmp_result=} @e")
+
+                    try:
+                        tmp_result = output == in_outs["outputs"][index]
+                    except Exception as e:
+                        if debug:
+                            print(f"Failed check4 exception = {e}")
+                        continue
+
+                    if tmp_result == True:
+                        results.append(tmp_result)
+                        continue
+
+                    if debug:
+                        print(f"{tmp_result=} @f")
+
+                    # try by converting the output into a split up list too
+                    if isinstance(output, list):
+                        for tmp_index, i in enumerate(output):
+                            output[tmp_index] = i.split()
+                        output = list(filter(len, output))
+                        for tmp_index, i in enumerate(output):
+                            output[tmp_index] = set(i)
+                    else:
+                        output = output.split()
+                        output = list(filter(len, output))
+                        output = set(output)
+
+                    if debug:
+                        print(f"{tmp_result=} @g")
+                    # try:
+                    #     tmp_result = set(frozenset(s) for s in output) == set(
+                    #         frozenset(s) for s in in_outs["outputs"][index]
+                    #     )
+                    # except Exception as e:
+                    #     if debug:
+                    #         print(f"Failed check5 exception = {e}")
+
+                    # if they are all numbers, round so that similar numbers are treated as identical
+                    # try:
+                    #     all_ints = all(
+                    #         combined_int_check(e1) and combined_int_check(e2)
+                    #         for e1, e2 in zip(output, in_outs["outputs"][index])
+                    #     )
+                    #     tmp_result = tmp_result or (
+                    #         set(frozenset(round(float(t), 3) for t in s) for s in output)
+                    #         == set(
+                    #             frozenset(round(float(t), 3) for t in s)
+                    #             for s in in_outs["outputs"][index]
+                    #         )
+                    #     )
+                    # except Exception as e:
+                    #     if debug:
+                    #         print(f"Failed check6 exception = {e}")
+
+                    if debug:
+                        print(f"{tmp_result=} @h")
+
+                    if tmp_result == True and debug:
+                        print("PASSED")
+
+                    results.append(tmp_result)
+                    if tmp_result != True:
+                        return results, {
+                            "output": raw_true_output_copy,
+                            "expected": raw_outputs,
+                            "inputs": raw_inputs,
+                            "error_code": -2,
+                            "error_message": "Wrong Answer",
+                        }
+
+                    if debug:
+                        nl = "\n"
+                        if not isinstance(inputs, list):
+                            print(
+                                f"@2 output = {output}, test outputs = {in_outs['outputs'][index]}, inputs = {inputs.replace(nl,' new-line ')}, {type(inputs)}, {output == [in_outs['outputs'][index]]}"
+                            )
+                        else:
+                            print(
+                                f"@2 output = {output}, test outputs = {in_outs['outputs'][index]}, inputs = {inputs}, {type(inputs)}, {output == [in_outs['outputs'][index]]}"
+                            )
+
+                        print(f"results = {results}")
 
     return results, {}
 
@@ -699,87 +698,129 @@ def call_method(method, inputs):
     return _inner_call_method(method)
 
 
+class ReliabilityGuard:
+    """
+    A context manager that disables various destructive functions and prevents the generated code
+    from interfering with the test (e.g. fork bomb, killing other processes,
+    removing filesystem files, etc.)
+
+    WARNING
+    This class is NOT a security sandbox. Untrusted code, including, model-
+    generated code, should not be blindly executed outside of one. See the
+    Codex paper for more information about OpenAI's code sandbox, and proceed
+    with caution.
+    """
+    def __init__(self, maximum_memory_bytes=None):
+        self.maximum_memory_bytes = maximum_memory_bytes
+        self.original_functions = {}
+    
+    def __enter__(self):
+        if self.maximum_memory_bytes is not None:
+            import resource
+
+            resource.setrlimit(
+                resource.RLIMIT_AS, (self.maximum_memory_bytes, self.maximum_memory_bytes)
+            )
+            resource.setrlimit(
+                resource.RLIMIT_DATA, (self.maximum_memory_bytes, self.maximum_memory_bytes)
+            )
+            if not platform.uname().system == "Darwin":
+                resource.setrlimit(
+                    resource.RLIMIT_STACK, (self.maximum_memory_bytes, self.maximum_memory_bytes)
+                )
+
+        faulthandler.disable()
+
+        import builtins
+        
+        # Save and disable builtins
+        self.original_functions['builtins.exit'] = builtins.exit
+        self.original_functions['builtins.quit'] = builtins.quit
+        self.original_functions['builtins.help'] = __builtins__["help"]
+        
+        builtins.exit = None
+        builtins.quit = None
+        __builtins__["help"] = None
+
+        import os
+        
+        os.environ["OMP_NUM_THREADS"] = "1"
+        
+        # Save and disable os functions
+        for func_name in [
+            'kill', 'system', 'putenv', 'remove', 'removedirs', 'rmdir', 'fchdir',
+            'setuid', 'fork', 'forkpty', 'killpg', 'rename', 'renames', 'truncate',
+            'replace', 'unlink', 'fchmod', 'fchown', 'chmod', 'chown', 'chroot',
+            'fchdir', 'lchflags', 'lchmod', 'lchown', 'getcwd', 'chdir'
+        ]:
+            if hasattr(os, func_name):
+                self.original_functions[f'os.{func_name}'] = getattr(os, func_name)
+                setattr(os, func_name, None)
+
+        import shutil
+        
+        # Save and disable shutil functions
+        for func_name in ['rmtree', 'move', 'chown']:
+            if hasattr(shutil, func_name):
+                self.original_functions[f'shutil.{func_name}'] = getattr(shutil, func_name)
+                setattr(shutil, func_name, None)
+
+        import subprocess
+        
+        # Save and disable subprocess functions
+        if hasattr(subprocess, 'Popen'):
+            self.original_functions['subprocess.Popen'] = subprocess.Popen
+            subprocess.Popen = None  # type: ignore
+
+        # Disable potentially dangerous modules
+        import sys
+        
+        for module_name in ['ipdb', 'joblib', 'resource', 'psutil', 'tkinter']:
+            sys.modules[module_name] = None
+            
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # Restore all original functions
+        for func_path, original_func in self.original_functions.items():
+            module_name, func_name = func_path.split('.')
+            
+            if module_name == 'builtins':
+                if func_name == 'help':
+                    __builtins__["help"] = original_func
+                else:
+                    import builtins
+                    setattr(builtins, func_name, original_func)
+            elif module_name == 'os':
+                import os
+                setattr(os, func_name, original_func)
+            elif module_name == 'shutil':
+                import shutil
+                setattr(shutil, func_name, original_func)
+            elif module_name == 'subprocess':
+                import subprocess
+                setattr(subprocess, func_name, original_func)
+                
+        # Re-enable faulthandler
+        faulthandler.enable()
+
+
 def reliability_guard(maximum_memory_bytes=None):
     """
     This disables various destructive functions and prevents the generated code
     from interfering with the test (e.g. fork bomb, killing other processes,
     removing filesystem files, etc.)
+
     WARNING
     This function is NOT a security sandbox. Untrusted code, including, model-
     generated code, should not be blindly executed outside of one. See the
     Codex paper for more information about OpenAI's code sandbox, and proceed
     with caution.
+    
+    This function is deprecated. Use the ReliabilityGuard context manager instead.
     """
-
-    if maximum_memory_bytes is not None:
-        import resource
-
-        resource.setrlimit(
-            resource.RLIMIT_AS, (maximum_memory_bytes, maximum_memory_bytes)
-        )
-        resource.setrlimit(
-            resource.RLIMIT_DATA, (maximum_memory_bytes, maximum_memory_bytes)
-        )
-        if not platform.uname().system == "Darwin":
-            resource.setrlimit(
-                resource.RLIMIT_STACK, (maximum_memory_bytes, maximum_memory_bytes)
-            )
-
-    faulthandler.disable()
-
-    import builtins
-
-    builtins.exit = None
-    builtins.quit = None
-
-    import os
-
-    os.environ["OMP_NUM_THREADS"] = "1"
-
-    os.kill = None
-    os.system = None
-    os.putenv = None
-    os.remove = None
-    os.removedirs = None
-    os.rmdir = None
-    os.fchdir = None
-    os.setuid = None
-    os.fork = None
-    os.forkpty = None
-    os.killpg = None
-    os.rename = None
-    os.renames = None
-    os.truncate = None
-    os.replace = None
-    os.unlink = None
-    os.fchmod = None
-    os.fchown = None
-    os.chmod = None
-    os.chown = None
-    os.chroot = None
-    os.fchdir = None
-    os.lchflags = None
-    os.lchmod = None
-    os.lchown = None
-    os.getcwd = None
-    os.chdir = None
-
-    import shutil
-
-    shutil.rmtree = None
-    shutil.move = None
-    shutil.chown = None
-
-    import subprocess
-
-    subprocess.Popen = None  # type: ignore
-
-    __builtins__["help"] = None
-
-    import sys
-
-    sys.modules["ipdb"] = None
-    sys.modules["joblib"] = None
-    sys.modules["resource"] = None
-    sys.modules["psutil"] = None
-    sys.modules["tkinter"] = None
+    # For backwards compatibility, create a ReliabilityGuard and enter it,
+    # but never exit (this maintains the original behavior)
+    guard = ReliabilityGuard(maximum_memory_bytes)
+    guard.__enter__()
+    return guard

--- a/livebench/lcb_runner/evaluation/testing_util.py
+++ b/livebench/lcb_runner/evaluation/testing_util.py
@@ -18,8 +18,6 @@ from io import StringIO
 # used for testing the code that reads from input
 from unittest.mock import patch, mock_open
 
-from pyext import RuntimeModule
-
 from enum import Enum
 
 
@@ -78,6 +76,32 @@ def string_int_check(val):
 
 def combined_int_check(val):
     return only_int_check(val) or string_int_check(val)
+
+
+class RuntimeModule:
+    @staticmethod
+    def from_string(name, docstring, code_string):
+        """
+        Create a module from a string of code.
+        
+        Args:
+            name: The name of the module
+            docstring: The docstring for the module
+            code_string: The Python code as a string
+            
+        Returns:
+            A module object with the executed code
+        """
+        import types
+        module = types.ModuleType(name, docstring)
+        
+        # Add the module to sys.modules to handle potential circular imports
+        sys.modules[name] = module
+        
+        # Execute the code string in the module's namespace
+        exec(code_string, module.__dict__)
+        
+        return module
 
 
 def run_test(sample, test=None, debug=False, timeout=6):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dependencies = [
     "accelerate>=0.21", "aiohttp", "anthropic>=0.3", "antlr4-python3-runtime==4.11", "datasets", "fastapi", "httpx", "immutabledict", "langchain", "langdetect", 
-    "levenshtein>=0.20.4", "lxml", "markdown2[all]", "nh3", "nltk", "numpy", "openai", "fastchat",
+    "levenshtein>=0.20.4", "lxml", "markdown2[all]", "nh3", "nltk", "numpy<2.0.0", "openai", "fastchat",
     "packaging", "pandas==2.2.2", "peft", "prompt_toolkit>=3.0.0", "protobuf", "pydantic", "psutil", "ray", "requests", "rich>=10.0.0",
     "sentencepiece", "shortuuid", "sympy>=1.12", "tiktoken", "torch", "transformers>=4.31.0", "tqdm>=4.62.1", "uvicorn", "wheel",
     "fschat@git+https://github.com/lm-sys/FastChat#egg=c5223e34babd24c3f9b08205e6751ea6e42c9684", "tenacity", "lark", "libtmux"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "accelerate>=0.21", "aiohttp", "anthropic>=0.3", "antlr4-python3-runtime==4.11", "datasets", "fastapi", "httpx", "immutabledict", "langchain", "langdetect", 
     "levenshtein>=0.20.4", "lxml", "markdown2[all]", "nh3", "nltk", "numpy", "openai", "fastchat",
-    "packaging", "pandas==2.2.2", "peft", "prompt_toolkit>=3.0.0", "protobuf", "pydantic", "pyext==0.7", "psutil", "ray", "requests", "rich>=10.0.0",
+    "packaging", "pandas==2.2.2", "peft", "prompt_toolkit>=3.0.0", "protobuf", "pydantic", "psutil", "ray", "requests", "rich>=10.0.0",
     "sentencepiece", "shortuuid", "sympy>=1.12", "tiktoken", "torch", "transformers>=4.31.0", "tqdm>=4.62.1", "uvicorn", "wheel",
     "fschat@git+https://github.com/lm-sys/FastChat#egg=c5223e34babd24c3f9b08205e6751ea6e42c9684", "tenacity", "lark", "libtmux"
 ]


### PR DESCRIPTION
Addresses #149

This PR makes LiveBench compatible with Python 3.11 and 3.12
(Possibly also 3.13, though that's untested)

[pyext](https://github.com/refi64/PyExt) is not compatible with Python 3.11 and the project is no longer supported.
This PR re-implements the only aspect of pyext used by LiveBench, `RuntimeModule` and removes the dependency.

Python 3.11 also changed the way it does cleanup on process exit, so this error was occurring on the judging of each question:
```
Traceback (most recent call last):                                                                                                                                                                     | 0/1 [00:00<?, ?it/s]
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/weakref.py", line 666, in _exitfunc
    f()
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/weakref.py", line 590, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/tempfile.py", line 933, in _cleanup
    cls._rmtree(name, ignore_errors=ignore_errors)
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/tempfile.py", line 929, in _rmtree
    _shutil.rmtree(name, onerror=onerror)
TypeError: 'NoneType' object is not callable
```
The code still functioned though.

The error (and others like it) was happening because `reliability_guard` was removing `shutil.rmtree`, `shutil.unlink`, etc, which python 3.11 calls during cleanup.
To counter this, I updated `reliability_guard` to be a context manager, and restore the functions that it disables when the context is exited.
The line count on the PR is a bit scary, but 90% of it is just an extra indent for the code in the `run_test` function since it's now in a context manager. We could potentially turn `ReliabilityGuard` into a function decorator to reduce the diff -- then it would look like below, and the code wouldn't need the extra indent.
```python
@ReliabilityGuard()
def run_test(sample, test=None, debug=False, timeout=6):
    """
    if test(generated_code) is not None it'll try to run the code.
    otherwise it'll just return an input and output pair.
    """
    if debug:
        print(f"start = {datetime.now().time()}")
    ...
```

Testing with Python 3.12 revealed that it installed numpy 2.2.3, which has compatibility issues with torch. Python 3.10 and 3.11 environments install numpy 1.26.4 automatically, so pinning numpy<2.0.0 seems like the best option.
Python 3.12 also has automatic regex pattern syntax warnings, which revealed a couple of f-strings that should have been r-strings.

## Testing
I've run `python run_livebench.py --model gpt-4o-mini --question-source huggingface --bench-name live_bench/coding/coding_completion --question-end=5` and `python -u gen_ground_truth_judgment.py --model gpt-4o-mini --question-source huggingface --bench-name live_bench/coding/coding_completion --remove-existing-file --question-end=5` with both Python 3.10 and 3.11 and got the same scores for the 5 answers.

Also the following test passes:
```python
def test_runtime_module():
    # Test code to execute
    test_code = """
def add(a, b):
    return a + b

class TestClass:
    def multiply(self, a, b):
        return a * b
    
value = 42
"""

    # Create a module from the string
    module = RuntimeModule.from_string("test_module", "Test module docstring", test_code)
    
    # Test function call
    result1 = module.add(5, 3)
    print(f"add(5, 3) = {result1}")
    
    # Test class instantiation and method call
    test_instance = module.TestClass()
    result2 = test_instance.multiply(5, 3)
    print(f"TestClass().multiply(5, 3) = {result2}")
    
    # Test variable access
    print(f"value = {module.value}")
    
    # Test docstring
    print(f"module.__doc__ = {module.__doc__}")
    
    print("All tests passed!")
```