### PR TITLE
fix: propagate --parallel to gen_ground_truth_judgement

### DIFF
--- a/livebench/run_livebench.py
+++ b/livebench/run_livebench.py
@@ -238,6 +238,7 @@ def build_run_command(
         gen_api_cmd += f" --max-tokens {max_tokens}"
     if parallel_requests:
         gen_api_cmd += f" --parallel {parallel_requests}"
+        gen_judge_cmd += f" --parallel {parallel_requests}"
     if resume:
         gen_api_cmd += " --resume"
         gen_judge_cmd += " --resume"


### PR DESCRIPTION
# Pull Request Template

## Description

Propagates the `parallel_requests` argument from `run_livebench.py` to `gen_ground_truth_judgment.py`, which accepts the `--parallel` argument.

## Related Issue(s)

None.

## Proposed Changes
- Adds `-parallel` command line argument to `gen_judge_cmd` in `run_livebench.py`

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)
- ◻️ New feature (non-breaking change which adds functionality)
- ◻️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- ◻️ Documentation update
- ◻️ Code style update (formatting, renaming)
- ◻️ Refactoring (no functional changes, no API changes)
- ◻️ Performance improvement
- ◻️ Tests
- ◻️ Build configuration change
- ◻️ Other (please describe):

## How Has This Been Tested?

Run `python run_livebench.py --model gpt-4o --bench-name live_bench/coding --parallel-requests 10`

## Testing Environment
- OS: MacOS
- Dependencies/Versions:  Python 3.10

## Checklist:
- ✅  My code follows the style guidelines of this project
- ✅  I have performed a self-review