### PR TITLE
feat: Add --min-release-date flag to filter questions

### DIFF
--- a/livebench/common.py
+++ b/livebench/common.py
@@ -121,7 +121,8 @@ def get_categories_tasks(bench_name: str):
 
     else:
         # specify a category or task
-        category_name = split_bench_name[1].split('_')[0]
+        # category_name = split_bench_name[1].split('_')[0]
+        category_name = split_bench_name[1]
 
         categories = {category_name: get_hf_dataset(category_name)}
 

--- a/livebench/common.py
+++ b/livebench/common.py
@@ -180,6 +180,7 @@ def load_questions(
     livebench_release: Optional[str] = None,
     task_name: Optional[str] = None,
     question_ids: Optional[list[str]] = None,
+    min_release_date: Optional[str] = None,
 ) -> list[dict]:
     """
     Load questions from a huggingface dataset.
@@ -191,6 +192,7 @@ def load_questions(
         livebench_release: The current livebench release. If specified, questions that have been removed prior to this release will be filtered out.
         task_name: The desired task within the category. If specified, only questions for this task will be returned.
         question_ids: A list of question ids to include. If None, all questions will be included.
+        min_release_date: The minimum release date for questions. If specified, only questions released on or after this date will be returned.
     """
     if task_name is not None:
         questions = [
@@ -232,6 +234,13 @@ def load_questions(
 
     if question_ids is not None:
         questions = [q for q in questions if q['question_id'] in question_ids]
+
+    if min_release_date:
+        min_date = datetime.strptime(min_release_date, "%Y-%m-%d").date()
+        questions = [
+            q for q in questions
+            if datetime.strptime(q["livebench_release_date"], "%Y-%m-%d").date() >= min_date
+        ]
     return questions
 
 
@@ -240,6 +249,7 @@ def load_questions_jsonl(
     livebench_releases: set = LIVE_BENCH_RELEASES,
     livebench_release: Optional[str] = None,
     question_ids: Optional[list[str]] = None,
+    min_release_date: Optional[str] = None,
 ):
     """
     Load questions from a jsonl file.
@@ -248,8 +258,9 @@ def load_questions_jsonl(
     Args:
         question_file: The filename of the question file
         livebench_releases: A set of valid release dates. Questions with other release dates will be filtered out.
-        livebench_release: The current livebench release. If specified, questions that have been removed prior to this release will be filtered out.\
+        livebench_release: The current livebench release. If specified, questions that have been removed prior to this release will be filtered out.
         question_ids: A list of question ids to include. If None, all questions will be included.
+        min_release_date: The minimum release date for questions. If specified, only questions released on or after this date will be returned.
     """
     questions = []
     with open(question_file, "r") as ques_file:
@@ -269,6 +280,13 @@ def load_questions_jsonl(
         
     if question_ids is not None:
         questions = [q for q in questions if str(q['question_id']) in question_ids]
+
+    if min_release_date:
+        min_date = datetime.strptime(min_release_date, "%Y-%m-%d").date()
+        questions = [
+            q for q in questions
+            if datetime.strptime(q["livebench_release_date"], "%Y-%m-%d").date() >= min_date
+        ]
     return questions
 
 def load_test_cases_jsonl(question_file_path: str, questions: list[dict]):
@@ -443,7 +461,6 @@ def get_model_list(answer_dir):
     file_names = [os.path.splitext(os.path.basename(f))[0].lower() for f in file_paths]
     return file_names
     
-
 def filter_questions(questions, answer_file, resume=False, retry_failures=False):
     """
     Filter questions based on the ones for which there are already answers in the answer_file.

--- a/livebench/gen_api_answer.py
+++ b/livebench/gen_api_answer.py
@@ -14,6 +14,7 @@ import shortuuid
 import tqdm
 import subprocess
 import sys
+from datetime import datetime
 
 from livebench.model.api_model_config import AgentConfig
 from livebench.agentic_code_runner.sweagent.run_inference import run_agentic_coding_inference
@@ -332,6 +333,12 @@ if __name__ == "__main__":
         help="Livebench release to use. Provide a single date option. Will handle excluding deprecated questions for selected release.",
     )
     parser.add_argument(
+        "--min-release-date",
+        type=str,
+        default=None,
+        help="Filter questions by minimum release date (e.g., YYYY-MM-DD)",
+    )
+    parser.add_argument(
         "--question-id",
         type=str,
         default=None,
@@ -415,7 +422,8 @@ if __name__ == "__main__":
                         release_set,
                         args.livebench_release_option,
                         task_name,
-                        args.question_id
+                        args.question_id,
+                        args.min_release_date
                     )
 
                     questions = questions[args.question_begin:args.question_end]
@@ -465,7 +473,8 @@ if __name__ == "__main__":
                         release_set,
                         args.livebench_release_option,
                         task_name,
-                        args.question_id
+                        args.question_id,
+                        args.min_release_date
                     )
 
                     questions = questions[args.question_begin:args.question_end]
@@ -522,7 +531,7 @@ if __name__ == "__main__":
             for question_file in list_of_question_files:
                 print(question_file)
                 questions = load_questions_jsonl(
-                    question_file, release_set, args.livebench_release_option, args.question_id
+                    question_file, release_set, args.livebench_release_option, args.question_id, args.min_release_date
                 )
                 
                 questions = questions[args.question_begin:args.question_end]
@@ -567,7 +576,7 @@ if __name__ == "__main__":
             for question_file in list_of_question_files:
                 print(question_file)
                 questions = load_questions_jsonl(
-                    question_file, release_set, args.livebench_release_option, args.question_id
+                    question_file, release_set, args.livebench_release_option, args.question_id, args.min_release_date
                 )
                 
                 questions = questions[args.question_begin:args.question_end]

--- a/livebench/gen_ground_truth_judgment.py
+++ b/livebench/gen_ground_truth_judgment.py
@@ -9,6 +9,7 @@ import time
 import os
 import re
 import glob
+from datetime import datetime
 
 import nltk
 import numpy as np
@@ -484,6 +485,12 @@ if __name__ == "__main__":
         help="Livebench release to use. Provide a single date option. Will handle excluding deprecated questions for selected release."
     )
     parser.add_argument(
+        "--min-release-date",
+        type=str,
+        default=None,
+        help="Filter questions by minimum release date (e.g., YYYY-MM-DD)",
+    )
+    parser.add_argument(
         "--debug", action="store_true", default=False,
         help="Print debug information."
     )
@@ -542,7 +549,7 @@ if __name__ == "__main__":
 
             for category_name, task_names in tasks.items():
                 for task_name in task_names:
-                    questions = load_questions(categories[category_name], release_set, args.livebench_release_option, task_name, args.question_id)
+                    questions = load_questions(categories[category_name], release_set, args.livebench_release_option, task_name, args.question_id, args.min_release_date)
                     if args.first_n:
                         questions = questions[: args.first_n]
                     questions = questions[args.question_begin:args.question_end]
@@ -576,7 +583,7 @@ if __name__ == "__main__":
                 list_of_question_files = glob.glob(f"data/{bench_name}/**/question.jsonl", recursive=True)
             for question_file in list_of_question_files:
                 print('questions from', question_file)
-                questions = load_questions_jsonl(question_file, release_set, args.livebench_release_option, args.question_id)
+                questions = load_questions_jsonl(question_file, release_set, args.livebench_release_option, args.question_id, args.min_release_date)
                 questions = load_test_cases_jsonl(question_file, questions)
                 if args.first_n:
                     questions = questions[: args.first_n]
@@ -604,4 +611,3 @@ if __name__ == "__main__":
 
     else:
         raise ValueError(f"Bad question source {args.question_source}.")
-    

--- a/livebench/gen_ground_truth_judgment.py
+++ b/livebench/gen_ground_truth_judgment.py
@@ -91,7 +91,7 @@ def play_a_match_gt(match: MatchSingle, output_file: str | None = None, debug=Fa
     question_text = question["turns"][0]
     ground_truth = question.get("ground_truth", None)
     llm_answer = answer['choices'][0]['turns'][-1]
-    llm_answer = re.sub(f"<think>.*?<\/think>", "", llm_answer, flags=re.DOTALL)
+    llm_answer = re.sub(f"<think>.*?</think>", "", llm_answer, flags=re.DOTALL)
     score = 0
     category = None
 
@@ -356,7 +356,7 @@ def gen_judgments(
 
         for m in model_answers:
             for q in model_answers[m]:
-                model_answers[m][q]['choices'][0]['turns'][0] = re.sub(f"<think>.*?<\/think>", "", model_answers[m][q]['choices'][0]['turns'][0], flags=re.DOTALL).strip()
+                model_answers[m][q]['choices'][0]['turns'][0] = re.sub(f"<think>.*?</think>", "", model_answers[m][q]['choices'][0]['turns'][0], flags=re.DOTALL).strip()
 
         for model_id in models:
             scores = instruction_following_process_results(questions, model_answers, task_name, model_id, debug)

--- a/livebench/process_results/writing/connections/utils.py
+++ b/livebench/process_results/writing/connections/utils.py
@@ -48,13 +48,13 @@ def connections_process_results_old(ground_truth: str, llm_answer: str, debug=Fa
 def connections_process_results(ground_truth: str, llm_answer: str, debug=False) -> int:
 
     # extract text from <solution></solution> tags
-    solution_matches = re.findall(r'<solution>(.*?)<\/solution>', llm_answer)
+    solution_matches = re.findall(r'<solution>(.*?)</solution>', llm_answer)
     if len(solution_matches) == 0:
-        solution_matches = re.findall(r'<solution>(.*?)<\/solution>', llm_answer.replace('\n', ''))
+        solution_matches = re.findall(r'<solution>(.*?)</solution>', llm_answer.replace('\n', ''))
     if len(solution_matches) == 0:
-        solution_matches = re.findall(r'</solution>(.*?)<\/solution>', llm_answer)
+        solution_matches = re.findall(r'</solution>(.*?)</solution>', llm_answer)
     if len(solution_matches) == 0:
-        solution_matches = re.findall(r'</solution>(.*?)<\/solution>', llm_answer.replace('\n', ''))
+        solution_matches = re.findall(r'</solution>(.*?)</solution>', llm_answer.replace('\n', ''))
 
     ground_truth_words = ground_truth.split(',')
 

--- a/livebench/run_livebench.py
+++ b/livebench/run_livebench.py
@@ -60,6 +60,7 @@ class LiveBenchParams:
     question_end: int | None = None
     question_id: list[str] | None = None
     livebench_release_option: str | None = None
+    min_release_date: str | None = None
     stream: bool = False
     remove_existing_judgment_file: bool = False
     ignore_missing_answers: bool = False
@@ -101,6 +102,7 @@ class LiveBenchParams:
             question_end=args.question_end,
             question_id=args.question_id,
             livebench_release_option=args.livebench_release_option,
+            min_release_date=args.min_release_date,
             stream=args.stream,
             remove_existing_judgment_file=args.remove_existing_judgment_file,
             ignore_missing_answers=args.ignore_missing_answers,
@@ -222,6 +224,7 @@ def build_run_command(
     question_end: int | None = None,
     question_id: list[str] | None = None,
     livebench_release_option: str | None = None,
+    min_release_date: str | None = None,
     stream: bool = False,
     remove_existing_judgment_file: bool = False,
     ignore_missing_answers: bool = False,
@@ -294,6 +297,9 @@ def build_run_command(
     if livebench_release_option:
         gen_api_cmd += f" --livebench-release-option {livebench_release_option}"
         gen_judge_cmd += f" --livebench-release-option {livebench_release_option}"
+    if min_release_date:
+        gen_api_cmd += f" --min-release-date {min_release_date}"
+        gen_judge_cmd += f" --min-release-date {min_release_date}"
     if stream:
         gen_api_cmd += " --stream"
     if remove_existing_judgment_file:
@@ -345,6 +351,7 @@ def build_run_command_from_params(params: LiveBenchParams, bench_name: str | Non
         question_end=params.question_end,
         question_id=params.question_id,
         livebench_release_option=params.livebench_release_option,
+        min_release_date=params.min_release_date,
         stream=params.stream,
         remove_existing_judgment_file=params.remove_existing_judgment_file,
         only_incorrect=params.only_incorrect,
@@ -484,6 +491,7 @@ def main():
     parser.add_argument("--question-end", type=int, help="Ending question index")
     parser.add_argument("--question-id", nargs="+", help="Specific question IDs to process")
     parser.add_argument("--livebench-release-option", help="LiveBench release option")
+    parser.add_argument("--min-release-date", help="Filter questions by minimum release date (e.g., YYYY-MM-DD)")
     parser.add_argument("--stream", action="store_true", help="Enable streaming mode")
     parser.add_argument("--remove-existing-judgment-file", action="store_true",
                       help="Remove existing judgment file before running")

--- a/livebench/show_livebench_result.py
+++ b/livebench/show_livebench_result.py
@@ -260,7 +260,7 @@ def display_result_single(args):
 
         for category_name, task_names in tasks.items():
             for task_name in task_names:
-                questions = load_questions(categories[category_name], release_set, args.livebench_release_option, task_name, None)
+                questions = load_questions(categories[category_name], release_set, args.livebench_release_option, task_name, None, args.min_release_date)
                 questions_all.extend(questions)
     elif args.question_source == "jsonl":
         for bench in args.bench_name:
@@ -273,7 +273,7 @@ def display_result_single(args):
 
             for question_file in list_of_question_files:
                 print(question_file)
-                questions = load_questions_jsonl(question_file, release_set, args.livebench_release_option, None)
+                questions = load_questions_jsonl(question_file, release_set, args.livebench_release_option, None, args.min_release_date)
                 questions_all.extend(questions)
 
     print('loaded ', len(questions_all), ' questions')
@@ -395,6 +395,12 @@ if __name__ == "__main__":
         default=max(LIVE_BENCH_RELEASES),
         choices=LIVE_BENCH_RELEASES,
         help="Livebench release to use. Provide a single date option. Will handle excluding deprecated questions for selected release."
+    )
+    parser.add_argument(
+        "--min-release-date",
+        type=str,
+        default=None,
+        help="Filter questions by minimum release date (e.g., YYYY-MM-DD)",
     )
     parser.add_argument(
         "--show-average-row",


### PR DESCRIPTION
This commit introduces a new command-line argument, `--min-release-date`, to run_livebench.py, gen_api_answer.py, and gen_ground_truth_judgment.py. This allows users to filter benchmark questions to include only those released on or after a specified date.

This is useful for evaluating models with a known knowledge cutoff date, preventing data contamination from questions the model may have seen during training.

The filtering logic has been refactored into the load_questions and load_questions_jsonl functions in livebench/common.py to avoid code duplication.

Solving feature request #276 