### PR TITLE
Dependencies: fix jinja to jinja2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "packaging", "pandas==2.2.2", "peft", "prompt_toolkit>=3.0.0", "protobuf", "pydantic", "psutil", "ray", "requests", "rich>=10.0.0",
     "sentencepiece", "shortuuid", "sympy>=1.12", "tiktoken", "torch", "transformers>=4.31.0", "tqdm>=4.62.1", "uvicorn", "wheel",
     "fschat@git+https://github.com/lm-sys/FastChat#egg=c5223e34babd24c3f9b08205e6751ea6e42c9684", "tenacity", "lark", "libtmux", "pyyaml", "dataclasses_json",
-    "docker", "gitpython", "toml", "PyGithub", "unidiff", "ruamel.yaml", "simple-parsing", "rich-argparse", "pydantic_settings", "litellm", "swe-rex>=1.4.0", "tabulate", "textual>=1.0.0", "jinja",
+    "docker", "gitpython", "toml", "PyGithub", "unidiff", "ruamel.yaml", "simple-parsing", "rich-argparse", "pydantic_settings", "litellm", "swe-rex>=1.4.0", "tabulate", "textual>=1.0.0", "jinja2",
     "typer", "platformdirs", "prompt_toolkit"
 ]
 


### PR DESCRIPTION
As far as I can tell you are using `jinja2` (based on searching for `jinja` and actually finding `from jinja2 import ...`).

[Jinja](https://pypi.org/project/Jinja/) is a package that hasn't been updated for 18 years. [Jinja2](https://pypi.org/project/Jinja2/) is a new package everyone is using (and the one you are importing from).