### PR TITLE
Require sympy>=1.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "anthropic>=0.3", "datasets", "httpx", "immutabledict", "langdetect", 
     "levenshtein>=0.20.4", "nltk", "numpy", "openai", "google-genai", "together",
     "pandas", "requests", "rich>=10.0.0",
-    "shortuuid", "sympy>=1.12", "tqdm>=4.62.1", "wheel", "tenacity", "lark", "libtmux", "pyyaml", "dataclasses_json",
+    "shortuuid", "sympy>=1.13", "tqdm>=4.62.1", "wheel", "tenacity", "lark", "libtmux", "pyyaml", "dataclasses_json",
     "docker", "gitpython", "toml", "PyGithub", "unidiff", "ruamel.yaml", "simple-parsing", "rich-argparse", "pydantic_settings", "litellm", "tabulate", "textual>=1.0.0", "jinja2",
     "typer", "platformdirs", "prompt_toolkit", "emoji", "syllapy", "unicodedata2", "spacy"
 ]


### PR DESCRIPTION
The `backend` parameter of `sympy.parsing.latex.parse_latex` was introduced in SymPy v1.13. This parameter is currently used in [`livebench/process_results/math/AMPS_Hard/utils.py`](https://github.com/LiveBench/LiveBench/blob/366e385d1ff6ad90ddeeb3644f1d72b2f7c6c324/livebench/process_results/math/AMPS_Hard/utils.py#L153). In SymPy <1.13, passing this unknown argument raises a `TypeError`, which the current error handling catches and reports as a misleading parsing warning like:

```console
/.../livebench/process_results/math/AMPS_Hard/utils.py:168: UserWarning: couldn't parse 16*2^{2/3} 5^{5/6}
```

```python
>>> sympy.__version__
'1.12.1'
>>> help(sympy.parsing.latex.parse_latex)
...
parse_latex(s)
...
```

```python
>>> sympy.__version__
'1.13.3'
>>> help(sympy.parsing.latex.parse_latex)
...
parse_latex(s, strict=False, backend='antlr')
...
```