### PR TITLE
fix: replace 22 bare excepts with except Exception

### DIFF
--- a/livebench/lcb_runner/evaluation/testing_util.py
+++ b/livebench/lcb_runner/evaluation/testing_util.py
@@ -80,7 +80,7 @@ def clean_if_name(code: str) -> str:
                 code = (
                     ast.unparse(astree.body[:-1]) + "\n" + ast.unparse(last_block.body)  # type: ignore
                 )
-    except:
+    except Exception:
         pass
 
     return code
@@ -178,7 +178,7 @@ def compile_code(code: str, timeout: int):
 def convert_line_to_decimals(line: str) -> tuple[bool, list[Decimal]]:
     try:
         decimal_line = [Decimal(elem) for elem in line.split()]
-    except:
+    except Exception:
         return False, []
     return True, decimal_line
 

--- a/livebench/process_results/coding/utils.py
+++ b/livebench/process_results/coding/utils.py
@@ -80,7 +80,7 @@ def LCB_generation_process_results(question: dict, llm_answer: str, debug=False)
 
     try:
         private_test_cases = json.loads(question['private_test_cases'])  # type: ignore
-    except:
+    except Exception:
         private_test_cases = json.loads(
             pickle.loads(
                 zlib.decompress(

--- a/livebench/process_results/data_analysis/tablejoin/utils.py
+++ b/livebench/process_results/data_analysis/tablejoin/utils.py
@@ -12,7 +12,7 @@ def clean_llm_output(s):
         return clean_llm_output(matches[-1].strip())
     try:
         match_d = literal_eval(s)
-    except:
+    except Exception:
         matches = re.findall('%s(.*?)%s' % ("```python", "```"), s.replace("\n",""),re.MULTILINE)
         if len(matches) == 0:
             matches = re.findall('%s(.*?)%s' % ("```json", "```"), s.replace("\n",""),re.MULTILINE)
@@ -31,7 +31,7 @@ def clean_llm_output(s):
         matches = matches.replace('null', 'None')
         try:
             match_d = literal_eval(matches)
-        except:
+        except Exception:
             return {}
     if not isinstance(match_d, dict):
         return {}

--- a/livebench/process_results/data_analysis/tablereformat/utils.py
+++ b/livebench/process_results/data_analysis/tablereformat/utils.py
@@ -12,19 +12,19 @@ def read_df_func(df_type, df_str):
     if df_type == "json":
         try:
             return pd.read_json(StringIO(df_str), orient="index", encoding="utf-8")
-        except:
+        except Exception:
             pass
         try:
             return pd.read_json(StringIO(df_str), orient="records", lines=False, encoding="utf-8")
-        except:
+        except Exception:
             pass
         try:
             return pd.read_json(StringIO(df_str), orient="records", lines=True, encoding="utf-8")
-        except:
+        except Exception:
             pass
         try:
             return pd.read_json(StringIO(df_str), orient="table", encoding="utf-8")
-        except:
+        except Exception:
             pass
         return pd.read_json(StringIO(df_str), orient="values", encoding="utf-8")
     elif df_type == "jsonl":
@@ -43,13 +43,13 @@ def read_df_func_v2(df_type, df_str):
         try:
             # Try table orientation first as it preserves dtypes
             return pd.read_json(StringIO(df_str), orient="table", encoding="utf-8")
-        except:
+        except Exception:
             try:
                 return pd.read_json(StringIO(df_str), orient="index", lines=False, encoding="utf-8")
-            except:
+            except Exception:
                 try:
                     return pd.read_json(StringIO(df_str), orient="records", lines=False, encoding="utf-8")
-                except:
+                except Exception:
                     print("Could not read JSON")
                     return None
     elif df_type == "jsonl":
@@ -112,7 +112,7 @@ def read_sep_table_from_text(text, header, sep=','):
      while parsed_table is None:
          try:
              parsed_table = pd.read_csv(StringIO('\n'.join(table)), sep=sep)
-         except:
+         except Exception:
              # in case there's extra text after the table
              table = table[:-1]
      return parsed_table
@@ -127,7 +127,7 @@ def read_jsonl_table_from_text(text, header):
             continue
         try:
             table.append(json.loads(line))
-        except:
+        except Exception:
             continue
     if len(table) == 0:
         return None
@@ -162,7 +162,7 @@ def table_process_results(input_command: str, ground_truth: str, llm_answer: str
     llm_df = None
     try:
         llm_df = df_read_func(output_format, llm_clean)
-    except:
+    except Exception:
         if output_format == 'csv' or output_format == 'tsv':
             header = (',', '\t')[output_format == 'tsv'].join(gt_df.columns)
             llm_df = read_sep_table_from_text(llm_clean, header, sep=',' if output_format == 'csv' else '\t')
@@ -218,7 +218,7 @@ def check_table_reformat(output_format, llm_df, gt_df, debug=False):
                     try:
                         llm_val = float(llm_val)
                         gt_val = float(gt_val)
-                    except:
+                    except Exception:
                         assert str(llm_val).strip() == str(gt_val).strip(), f"Mismatched types of values {llm_val} (LLM) vs {gt_val} (Ground Truth) for key {key} in row {i}"
                         continue
                     if math.isnan(llm_val) and math.isnan(gt_val):

--- a/livebench/process_results/math/AMPS_Hard/utils.py
+++ b/livebench/process_results/math/AMPS_Hard/utils.py
@@ -160,11 +160,11 @@ def parse(x: str) -> list[sympy.Expr]:
         try:
             # this almost only happened for amazon.nova-pro-v1:0 where it outputs e.g. \\frac or \\sqrt all the time
             parsed_xs = parse_latex(x.replace('\\\\', '\\'), backend='lark')
-        except:
+        except Exception:
             try:
                 # if all else fails, try to parse using default backend
                 parsed_xs = parse_latex(x)
-            except:
+            except Exception:
                 warnings.warn(f"couldn't parse {x}")
                 return []
 

--- a/livebench/process_results/math/olympiad/utils.py
+++ b/livebench/process_results/math/olympiad/utils.py
@@ -44,7 +44,7 @@ def extract_expression_completions_from_generation(generation, debug):
             n = n.strip().split(' ')[-1].replace('$', '').replace('{', '').replace('}', '').replace('\\', '').replace('boxed', '').replace('<', '').replace('>', '')
             try:
                 numbers.append(int(n))
-            except:
+            except Exception:
                 if debug:
                     print('ERROR', n)
                 numbers.append('NO ANSWER')
@@ -63,7 +63,7 @@ def extract_expression_completions_from_generation(generation, debug):
         for n in string.strip().split(','):
             try:
                 numbers.append(int(n.strip()))
-            except:
+            except Exception:
                 numbers.append('NO ANSWER')
         if len(numbers) == 0 or set(numbers) == {'NO ANSWER'}:
             numbers = None
@@ -78,7 +78,7 @@ def extract_expression_completions_from_generation(generation, debug):
                 continue
             try:
                 numbers.append(int(n.strip()))
-            except:
+            except Exception:
                 numbers.append('NO ANSWER')
         if len(numbers) == 0 or set(numbers) == {'NO ANSWER'}:
             numbers = None

--- a/livebench/run_livebench.py
+++ b/livebench/run_livebench.py
@@ -144,7 +144,7 @@ def setup_tmux_session(session_name: str, benchmarks: list[str], commands: list[
         if existing_sessions:
             print(f"Killing existing session '{session_name}'")
             existing_sessions[0].kill()
-    except:
+    except Exception:
         pass
 
     # Create new session


### PR DESCRIPTION
Replace 22 bare `except:` with `except Exception:` across 7 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.