### PR TITLE
Fixed bug that prevented running benches with underscores such as instruction_following

### DIFF
--- a/livebench/common.py
+++ b/livebench/common.py
@@ -121,7 +121,11 @@ def get_categories_tasks(bench_name: str):
 
     else:
         # specify a category or task
-        category_name = split_bench_name[1].split('_')[0]
+        category_name = split_bench_name[1]
+        if category_name not in LIVE_BENCH_CATEGORIES:
+            raise ValueError(
+                f"Unknown LiveBench category '{category_name}' in bench name '{bench_name}'"
+            )
 
         categories = {category_name: get_hf_dataset(category_name)}
 


### PR DESCRIPTION
The code was incorrectly splitting the bench name on the underscore character, which made it impossible to run `instruction_following` and `data_analysis` benches through the --bench-name command line argument.
This fix resolves that issue.