### PR TITLE
Spend tracking + litellm for llm inference 

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -37,6 +37,7 @@ class LitellmModel:
         self.n_calls = 0
         self.input_tokens = 0
         self.output_tokens = 0
+        self.cached_tokens = 0
         if self.config.litellm_model_registry and Path(self.config.litellm_model_registry).is_file():
             litellm.utils.register_model(json.loads(Path(self.config.litellm_model_registry).read_text()))
 
@@ -314,6 +315,8 @@ class LitellmModel:
                 del actual_kwargs['extra_body']
             if 'thinking' not in actual_kwargs:
                 actual_kwargs['thinking'] = {'type': 'disabled'}
+        if actual_kwargs.get('stream', False) and 'stream_options' not in actual_kwargs:
+            actual_kwargs['stream_options'] = {'include_usage': True}
         try:
             res = litellm.completion(
                 model=self.config.model_name, messages=messages, **actual_kwargs
@@ -343,6 +346,8 @@ class LitellmModel:
             result['content'] = content
             result['input_tokens'] = res.usage.prompt_tokens
             result['output_tokens'] = res.usage.completion_tokens
+            details = getattr(res.usage, 'prompt_tokens_details', None)
+            result['cached_tokens'] = (getattr(details, 'cached_tokens', 0) or 0) if details is not None else 0
         return result
 
     @retry(
@@ -445,7 +450,8 @@ class LitellmModel:
         self.n_calls += 1
         self.input_tokens += input_tokens
         self.output_tokens += output_tokens
-        
+        self.cached_tokens += result.get('cached_tokens', 0) or 0
+
         # Handle message serialization - some methods return Pydantic models, some return dicts
         message_data = None
         if 'message' in result:

--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -346,8 +346,9 @@ class LitellmModel:
             result['content'] = content
             result['input_tokens'] = res.usage.prompt_tokens
             result['output_tokens'] = res.usage.completion_tokens
-            details = getattr(res.usage, 'prompt_tokens_details', None)
-            result['cached_tokens'] = (getattr(details, 'cached_tokens', 0) or 0) if details is not None else 0
+            result['cached_tokens'] = 0
+            if hasattr(res.usage, 'prompt_tokens_details') and res.usage.prompt_tokens_details is not None:
+                result['cached_tokens'] = res.usage.prompt_tokens_details.cached_tokens or 0
         return result
 
     @retry(

--- a/livebench/agentic_code_runner/minisweagent/run/utils/save.py
+++ b/livebench/agentic_code_runner/minisweagent/run/utils/save.py
@@ -51,6 +51,7 @@ def save_traj(
                 "api_calls": 0,
                 "total_input_tokens": 0,
                 "total_output_tokens": 0,
+                "total_cached_tokens": 0,
             },
             "mini_version": __version__,
         },
@@ -62,6 +63,7 @@ def save_traj(
         data["info"]["model_stats"]["api_calls"] = agent.model.n_calls
         data["info"]["model_stats"]["total_input_tokens"] = agent.model.input_tokens
         data["info"]["model_stats"]["total_output_tokens"] = agent.model.output_tokens
+        data["info"]["model_stats"]["total_cached_tokens"] = getattr(agent.model, "cached_tokens", 0)
         for message in agent.messages:
             if 'extra' in message:
                 del message['extra']

--- a/livebench/agentic_code_runner/minisweagent/run_inference.py
+++ b/livebench/agentic_code_runner/minisweagent/run_inference.py
@@ -232,13 +232,14 @@ def run_agentic_coding_inference(
             except Exception:
                 cpm = None
             if cpm:
-                # agentic resends context each step, so most input is cached (read) tokens
                 cached = cached_tok if 'cached_input' in cpm else 0
                 uncached = max(in_tok - cached, 0)
                 cost_usd = round(
-                    uncached / 1e6 * cpm.get('input', 0)
-                    + cached / 1e6 * cpm.get('cached_input', cpm.get('input', 0))
-                    + out_tok / 1e6 * cpm.get('output', 0), 6)
+                    (uncached / 1_000_000) * cpm.get('input', 0)
+                    + (cached / 1_000_000) * cpm.get('cached_input', cpm.get('input', 0))
+                    + (out_tok / 1_000_000) * cpm.get('output', 0),
+                    6,
+                )
 
             ans.update({
                 'trajectory': json.dumps(trajectory, indent=4),

--- a/livebench/agentic_code_runner/minisweagent/run_inference.py
+++ b/livebench/agentic_code_runner/minisweagent/run_inference.py
@@ -9,6 +9,7 @@ from livebench.common import LIVE_BENCH_ROOT_PATH
 
 from livebench.process_results.coding.utils import agentic_coding_process_results
 from livebench.model.completions import API_ERROR_OUTPUT
+from livebench.model.api_model_config import get_model_config
 
 
 def update_dict_recursively(d1, d2):
@@ -221,11 +222,33 @@ def run_agentic_coding_inference(
 
             del trajectory['info']['submission']
 
+            stats = trajectory['info'].get('model_stats', {}) or {}
+            in_tok = stats.get('total_input_tokens') or 0
+            out_tok = stats.get('total_output_tokens') or 0
+            cached_tok = stats.get('total_cached_tokens') or 0
+            cost_usd = stats.get('instance_cost')
+            try:
+                cpm = get_model_config(model_name).cost_per_million
+            except Exception:
+                cpm = None
+            if cpm:
+                # agentic resends context each step, so most input is cached (read) tokens
+                cached = cached_tok if 'cached_input' in cpm else 0
+                uncached = max(in_tok - cached, 0)
+                cost_usd = round(
+                    uncached / 1e6 * cpm.get('input', 0)
+                    + cached / 1e6 * cpm.get('cached_input', cpm.get('input', 0))
+                    + out_tok / 1e6 * cpm.get('output', 0), 6)
+
             ans.update({
                 'trajectory': json.dumps(trajectory, indent=4),
                 'choices': [{'turns': [final_answer]}],
-                'total_output_tokens': trajectory['info']['model_stats']['total_output_tokens'],
-                'total_input_tokens': trajectory['info']['model_stats']['total_input_tokens'],
+                'total_output_tokens': out_tok,
+                'total_input_tokens': in_tok,
+                'total_cached_tokens': cached_tok,
+                'n_model_calls': stats.get('api_calls'),
+                'model_cost': stats.get('instance_cost'),
+                'cost_usd': cost_usd,
             })
 
         # Use answer_file parameter if provided (as override), otherwise use question's answer_file

--- a/livebench/gen_api_answer.py
+++ b/livebench/gen_api_answer.py
@@ -44,6 +44,7 @@ def get_answer(
     answer_file: str | None = None,
     model_display_name_override: str | None = None,
     model_provider_override: str | None = None,
+    use_litellm: bool = False,
 
 ):
     """
@@ -74,6 +75,8 @@ def get_answer(
     
     choices = []
     total_num_tokens = 0
+    total_input_tokens = 0
+    total_cached_tokens = 0
     for i in range(num_choices):
         messages = []
 
@@ -87,7 +90,7 @@ def get_answer(
                 prompt = model_config.prompt_prefix + "\n" + prompt
             messages.append({"role": "user", "content": prompt})
 
-            res = get_api_function(provider)(
+            res = get_api_function(provider, use_litellm)(
                 model=model_api_name,
                 messages=messages,
                 temperature=temperature,
@@ -104,6 +107,12 @@ def get_answer(
                 m = None
 
             if m is not None:
+                turn_input_tokens = m.pop('input_tokens', None)
+                if turn_input_tokens is not None:
+                    total_input_tokens += turn_input_tokens
+                turn_cached_tokens = m.pop('cached_tokens', None)
+                if turn_cached_tokens is not None:
+                    total_cached_tokens += turn_cached_tokens
                 metadata.update(m)
 
             messages.append({"role": "assistant", "content": output})
@@ -111,6 +120,19 @@ def get_answer(
             total_num_tokens += num_tokens
 
         choices.append({"index": i, "turns": turns})
+
+    cost_usd = None
+    if getattr(model_config, 'cost_per_million', None):
+        cpm = model_config.cost_per_million
+        out_tokens = total_num_tokens if total_num_tokens and total_num_tokens > 0 else 0
+        cached = total_cached_tokens if 'cached_input' in cpm else 0
+        uncached = max(total_input_tokens - cached, 0)
+        cost_usd = round(
+            (uncached / 1_000_000) * cpm.get('input', 0)
+            + (cached / 1_000_000) * cpm.get('cached_input', cpm.get('input', 0))
+            + (out_tokens / 1_000_000) * cpm.get('output', 0),
+            6,
+        )
 
     # Dump answers
     ans = {
@@ -120,6 +142,9 @@ def get_answer(
         "choices": choices,
         "tstamp": time.time(),
         "total_output_tokens": total_num_tokens,
+        "total_input_tokens": total_input_tokens,
+        "total_cached_tokens": total_cached_tokens,
+        "cost_usd": cost_usd,
         "api_info": {
             "provider": provider if provider != 'local' else api_dict['api_base'],
             "api_name": model_api_name,
@@ -193,6 +218,7 @@ def run_questions(
     model_provider_override: str | None,
     model_display_name_override: str | None = None,
     api_dict: dict[str, str] | None = None,
+    use_litellm: bool = False,
 ):
     """
     Perform inference on a list of questions. Output answers to answer_file.
@@ -256,6 +282,7 @@ def run_questions(
                     model_display_name_override=model_display_name_override,
                     answer_file=answer_file,
                     model_config=model_config,
+                    use_litellm=use_litellm,
                 )
         else:
             with concurrent.futures.ThreadPoolExecutor(max_workers=parallel) as executor:
@@ -275,6 +302,7 @@ def run_questions(
                         model_display_name_override=model_display_name_override,
                         answer_file=answer_file,
                         model_config=model_config,
+                        use_litellm=use_litellm,
                     )
                     futures.append(future)
 
@@ -391,6 +419,12 @@ if __name__ == "__main__":
         help="Stream responses, for models that support streaming"
     )
     parser.add_argument(
+        "--use-litellm",
+        action="store_true",
+        default=False,
+        help="Route requests through LiteLLM instead of the per-provider clients"
+    )
+    parser.add_argument(
         "--model-provider-override",
         type=str,
         default=None,
@@ -478,6 +512,7 @@ if __name__ == "__main__":
                 answer_file=None,  # Will use answer_file from question dict
                 api_dict=api_dict,
                 stream=args.stream,
+                use_litellm=args.use_litellm,
                 force_temperature=args.force_temperature,
                 model_provider_override=args.model_provider_override,
                 model_display_name_override=model_display_name
@@ -534,6 +569,7 @@ if __name__ == "__main__":
                 answer_file=None,  # Will use answer_file from question dict
                 api_dict=api_dict,
                 stream=args.stream,
+                use_litellm=args.use_litellm,
                 force_temperature=args.force_temperature,
                 model_provider_override=args.model_provider_override
             )

--- a/livebench/model/api_model_config.py
+++ b/livebench/model/api_model_config.py
@@ -15,6 +15,7 @@ class ModelConfig:
     api_kwargs: APIKwargs | None = None # mapping of provider name to additional arguments to pass to the API call
     prompt_prefix: str | None = None # prefix to add to the prompt
     preserve_reasoning: bool | None = None # whether to preserve reasoning in multi-turn tasks
+    cost_per_million: dict[str, float] | None = None # USD per 1M tokens; keys: input, cached_input, output
 
 @cache
 def load_model_configs(file_path: str) -> dict[str, ModelConfig]:

--- a/livebench/model/completions.py
+++ b/livebench/model/completions.py
@@ -95,6 +95,8 @@ def chat_completion_openai(
 
             message = ''
             num_tokens = None
+            input_tokens = None
+            cached_tokens = None
             try:
                 for chunk in stream:
                     if chunk.choices and len(chunk.choices) > 0 and chunk.choices[0].delta.content is not None:
@@ -103,6 +105,11 @@ def chat_completion_openai(
                         num_tokens = chunk.usage.completion_tokens
                         if hasattr(chunk.usage, 'reasoning_tokens'):
                             num_tokens += chunk.usage.reasoning_tokens
+                        if getattr(chunk.usage, 'prompt_tokens', None) is not None:
+                            input_tokens = chunk.usage.prompt_tokens
+                        details = getattr(chunk.usage, 'prompt_tokens_details', None)
+                        if details is not None and getattr(details, 'cached_tokens', None) is not None:
+                            cached_tokens = details.cached_tokens
             except Exception:
                 if message != '':
                     print(message)
@@ -123,12 +130,18 @@ def chat_completion_openai(
                 message = response.choices[0]
             else:
                 message = response.choices[0].message.content
+            input_tokens = None
+            cached_tokens = None
             if response.usage is not None:
                 num_tokens = response.usage.completion_tokens
                 if hasattr(response.usage, 'completion_tokens_details') and hasattr(response.usage.completion_tokens_details, 'reasoning_tokens'):
                     reasoning_tokens = response.usage.completion_tokens_details.reasoning_tokens
                     if num_tokens is not None and reasoning_tokens is not None:
                         num_tokens += reasoning_tokens
+                input_tokens = getattr(response.usage, 'prompt_tokens', None)
+                details = getattr(response.usage, 'prompt_tokens_details', None)
+                if details is not None:
+                    cached_tokens = getattr(details, 'cached_tokens', None)
             else:
                 num_tokens = None
 
@@ -147,6 +160,10 @@ def chat_completion_openai(
         output = message
 
         metadata: dict[str, Any] | None = None
+        if input_tokens is not None:
+            metadata = {'input_tokens': input_tokens}
+            if cached_tokens is not None:
+                metadata['cached_tokens'] = cached_tokens
 
         return output, num_tokens, metadata
     except Exception as e:
@@ -624,7 +641,80 @@ def chat_completion_deepinfra(model: str, messages: Conversation, temperature: f
 
     return ai_message['content'], total_tokens
 
-def get_api_function(provider_name: str) -> ModelAPI:
+@retry(
+    stop=stop_after_attempt(API_MAX_RETRY),
+    wait=wait_fixed(API_RETRY_SLEEP_MIN),
+    retry=retry_if_exception_type(Exception),
+    after=retry_log,
+    retry_error_callback=retry_fail
+)
+def chat_completion_litellm(
+    model: str, messages: Conversation, temperature: float, max_tokens: int, model_api_kwargs: API_Kwargs | None = None, api_dict: dict[str, str] | None = None, stream: bool = False
+) -> tuple[str, int, dict[str, Any] | None]:
+    """Provider-agnostic path via LiteLLM, selected by the --use-litellm flag."""
+    import litellm
+
+    api_kwargs: dict[str, Any] = {'temperature': temperature}
+    if model_api_kwargs is not None:
+        api_kwargs.update({k: v for k, v in model_api_kwargs.items()})
+    if 'max_tokens' not in api_kwargs and 'max_completion_tokens' not in api_kwargs:
+        api_kwargs['max_tokens'] = max_tokens
+    if 'stream' in api_kwargs:
+        stream = bool(api_kwargs.pop('stream'))
+    api_kwargs = {k: v for k, v in api_kwargs.items() if v is not None}
+
+    call: dict[str, Any] = {'messages': messages, **api_kwargs}
+    if api_dict is not None and api_dict.get('api_base'):
+        call['api_base'] = api_dict['api_base']
+        if api_dict.get('api_key'):
+            call['api_key'] = api_dict['api_key']
+        call['model'] = f"openai/{model}"
+    else:
+        call['model'] = model
+
+    def _read_usage(usage):
+        n_out = getattr(usage, 'completion_tokens', None)
+        det = getattr(usage, 'completion_tokens_details', None)
+        if n_out is not None and det is not None and getattr(det, 'reasoning_tokens', None):
+            n_out += det.reasoning_tokens
+        n_in = getattr(usage, 'prompt_tokens', None)
+        pdet = getattr(usage, 'prompt_tokens_details', None)
+        n_cached = getattr(pdet, 'cached_tokens', None) if pdet is not None else None
+        return n_out, n_in, n_cached
+
+    message = ''
+    num_tokens = input_tokens = cached_tokens = None
+    if stream:
+        call['stream'] = True
+        call['stream_options'] = {'include_usage': True}
+        for chunk in litellm.completion(**call):
+            if chunk.choices and getattr(chunk.choices[0].delta, 'content', None):
+                message += chunk.choices[0].delta.content
+            if getattr(chunk, 'usage', None) is not None:
+                num_tokens, input_tokens, cached_tokens = _read_usage(chunk.usage)
+    else:
+        resp = litellm.completion(**call)
+        message = resp.choices[0].message.content
+        if getattr(resp, 'usage', None) is not None:
+            num_tokens, input_tokens, cached_tokens = _read_usage(resp.usage)
+
+    if message is None or message == '':
+        raise Exception("No message returned from litellm")
+    if num_tokens is None:
+        num_tokens = -1
+
+    metadata: dict[str, Any] | None = None
+    if input_tokens is not None:
+        metadata = {'input_tokens': input_tokens}
+        if cached_tokens is not None:
+            metadata['cached_tokens'] = cached_tokens
+
+    return message, num_tokens, metadata
+
+
+def get_api_function(provider_name: str, use_litellm: bool = False) -> ModelAPI:
+    if use_litellm:
+        return chat_completion_litellm
     if provider_name == 'openai':
         return chat_completion_openai
     elif provider_name == 'openai_responses':

--- a/livebench/model/completions.py
+++ b/livebench/model/completions.py
@@ -676,47 +676,31 @@ def chat_completion_litellm(
     else:
         litellm_model = model
 
-    message = ''
+    if stream and 'stream_options' not in actual_api_kwargs:
+        actual_api_kwargs['stream_options'] = {'include_usage': True}
+
+    response = litellm.completion(
+        model=litellm_model, messages=messages, stream=stream, **actual_api_kwargs
+    )
+
+    if stream:
+        chunks = list(response)
+        response = litellm.stream_chunk_builder(chunks, messages=messages)
+
+    message = response.choices[0].message.content
+
     num_tokens = None
     input_tokens = None
     cached_tokens = None
-    if stream:
-        response = litellm.completion(
-            model=litellm_model,
-            messages=messages,
-            stream=True,
-            stream_options={'include_usage': True},
-            **actual_api_kwargs
-        )
-        for chunk in response:
-            if chunk.choices and len(chunk.choices) > 0 and chunk.choices[0].delta.content is not None:
-                message += chunk.choices[0].delta.content
-            if chunk.usage is not None:
-                num_tokens = chunk.usage.completion_tokens
-                if hasattr(chunk.usage, 'completion_tokens_details') and chunk.usage.completion_tokens_details is not None:
-                    reasoning_tokens = getattr(chunk.usage.completion_tokens_details, 'reasoning_tokens', None)
-                    if num_tokens is not None and reasoning_tokens is not None:
-                        num_tokens += reasoning_tokens
-                input_tokens = chunk.usage.prompt_tokens
-                if hasattr(chunk.usage, 'prompt_tokens_details') and chunk.usage.prompt_tokens_details is not None:
-                    cached_tokens = chunk.usage.prompt_tokens_details.cached_tokens
-    else:
-        response = litellm.completion(
-            model=litellm_model,
-            messages=messages,
-            stream=False,
-            **actual_api_kwargs
-        )
-        message = response.choices[0].message.content
-        if response.usage is not None:
-            num_tokens = response.usage.completion_tokens
-            if hasattr(response.usage, 'completion_tokens_details') and response.usage.completion_tokens_details is not None:
-                reasoning_tokens = getattr(response.usage.completion_tokens_details, 'reasoning_tokens', None)
-                if num_tokens is not None and reasoning_tokens is not None:
-                    num_tokens += reasoning_tokens
-            input_tokens = response.usage.prompt_tokens
-            if hasattr(response.usage, 'prompt_tokens_details') and response.usage.prompt_tokens_details is not None:
-                cached_tokens = response.usage.prompt_tokens_details.cached_tokens
+    if response.usage is not None:
+        num_tokens = response.usage.completion_tokens
+        if hasattr(response.usage, 'completion_tokens_details') and response.usage.completion_tokens_details is not None:
+            reasoning_tokens = getattr(response.usage.completion_tokens_details, 'reasoning_tokens', None)
+            if num_tokens is not None and reasoning_tokens is not None:
+                num_tokens += reasoning_tokens
+        input_tokens = response.usage.prompt_tokens
+        if hasattr(response.usage, 'prompt_tokens_details') and response.usage.prompt_tokens_details is not None:
+            cached_tokens = response.usage.prompt_tokens_details.cached_tokens
 
     if message is None or message == '':
         raise Exception("No message returned from litellm")

--- a/livebench/model/completions.py
+++ b/livebench/model/completions.py
@@ -646,7 +646,7 @@ def chat_completion_deepinfra(model: str, messages: Conversation, temperature: f
     retry_error_callback=retry_fail
 )
 def chat_completion_litellm(
-    model: str, messages: Conversation, temperature: float, max_tokens: int, model_api_kwargs: API_Kwargs | None = None, api_dict: dict[str, str] | None = None, stream: bool = False
+    model: str, messages: Conversation, temperature: float, max_tokens: int, model_api_kwargs: API_Kwargs | None = None, api_dict: dict[str, str] | None = None, stream: bool = False, provider: str | None = None
 ) -> tuple[str, int, dict[str, Any] | None]:
     """Provider-agnostic path via LiteLLM, selected by the --use-litellm flag."""
     import litellm
@@ -668,13 +668,38 @@ def chat_completion_litellm(
 
     actual_api_kwargs = {key: value for key, value in api_kwargs.items() if value is not None}
 
+    # LiveBench provider names → LiteLLM provider prefixes
+    litellm_provider_aliases = {'google': 'gemini', 'together': 'together_ai'}
+
     if api_dict is not None and api_dict.get('api_base'):
         litellm_model = f"openai/{model}"
         actual_api_kwargs['api_base'] = api_dict['api_base']
         if api_dict.get('api_key'):
             actual_api_kwargs['api_key'] = api_dict['api_key']
+    elif provider and provider not in ('local', ''):
+        litellm_model = f"{litellm_provider_aliases.get(provider, provider)}/{model}"
     else:
         litellm_model = model
+
+    # Provider-specific kwargs munging, mirroring
+    # livebench/agentic_code_runner/.../litellm_model.py:_query_completion
+    if 'deepseek' in litellm_model:
+        messages = [{**m, 'role': 'user'} if m.get('role') == 'system' else m for m in messages]
+
+    reasoning_param_name = 'thinking' if 'anthropic' in litellm_model else 'reasoning_effort'
+    if reasoning_param_name in actual_api_kwargs:
+        existing = actual_api_kwargs.get('allowed_openai_params') or []
+        actual_api_kwargs['allowed_openai_params'] = list(existing) + [reasoning_param_name]
+
+    if 'anthropic' in litellm_model:
+        if 'betas' in actual_api_kwargs:
+            actual_api_kwargs['extra_headers'] = {'anthropic-beta': beta for beta in actual_api_kwargs['betas']}
+            del actual_api_kwargs['betas']
+        if 'extra_body' in actual_api_kwargs:
+            actual_api_kwargs = actual_api_kwargs | actual_api_kwargs['extra_body']
+            del actual_api_kwargs['extra_body']
+        if 'thinking' not in actual_api_kwargs:
+            actual_api_kwargs['thinking'] = {'type': 'disabled'}
 
     if stream and 'stream_options' not in actual_api_kwargs:
         actual_api_kwargs['stream_options'] = {'include_usage': True}
@@ -718,7 +743,8 @@ def chat_completion_litellm(
 
 def get_api_function(provider_name: str, use_litellm: bool = False) -> ModelAPI:
     if use_litellm:
-        return chat_completion_litellm
+        from functools import partial
+        return partial(chat_completion_litellm, provider=provider_name)
     if provider_name == 'openai':
         return chat_completion_openai
     elif provider_name == 'openai_responses':

--- a/livebench/model/completions.py
+++ b/livebench/model/completions.py
@@ -105,11 +105,9 @@ def chat_completion_openai(
                         num_tokens = chunk.usage.completion_tokens
                         if hasattr(chunk.usage, 'reasoning_tokens'):
                             num_tokens += chunk.usage.reasoning_tokens
-                        if getattr(chunk.usage, 'prompt_tokens', None) is not None:
-                            input_tokens = chunk.usage.prompt_tokens
-                        details = getattr(chunk.usage, 'prompt_tokens_details', None)
-                        if details is not None and getattr(details, 'cached_tokens', None) is not None:
-                            cached_tokens = details.cached_tokens
+                        input_tokens = chunk.usage.prompt_tokens
+                        if hasattr(chunk.usage, 'prompt_tokens_details') and chunk.usage.prompt_tokens_details is not None:
+                            cached_tokens = chunk.usage.prompt_tokens_details.cached_tokens
             except Exception:
                 if message != '':
                     print(message)
@@ -138,10 +136,9 @@ def chat_completion_openai(
                     reasoning_tokens = response.usage.completion_tokens_details.reasoning_tokens
                     if num_tokens is not None and reasoning_tokens is not None:
                         num_tokens += reasoning_tokens
-                input_tokens = getattr(response.usage, 'prompt_tokens', None)
-                details = getattr(response.usage, 'prompt_tokens_details', None)
-                if details is not None:
-                    cached_tokens = getattr(details, 'cached_tokens', None)
+                input_tokens = response.usage.prompt_tokens
+                if hasattr(response.usage, 'prompt_tokens_details') and response.usage.prompt_tokens_details is not None:
+                    cached_tokens = response.usage.prompt_tokens_details.cached_tokens
             else:
                 num_tokens = None
 
@@ -654,49 +651,72 @@ def chat_completion_litellm(
     """Provider-agnostic path via LiteLLM, selected by the --use-litellm flag."""
     import litellm
 
-    api_kwargs: dict[str, Any] = {'temperature': temperature}
+    api_kwargs: API_Kwargs = {
+        'temperature': temperature
+    }
+
     if model_api_kwargs is not None:
-        api_kwargs.update({k: v for k, v in model_api_kwargs.items()})
+        model_api_kwargs = {key: value for key, value in model_api_kwargs.items()}
+        api_kwargs.update(model_api_kwargs)
+
     if 'max_tokens' not in api_kwargs and 'max_completion_tokens' not in api_kwargs:
         api_kwargs['max_tokens'] = max_tokens
+
     if 'stream' in api_kwargs:
-        stream = bool(api_kwargs.pop('stream'))
-    api_kwargs = {k: v for k, v in api_kwargs.items() if v is not None}
+        stream = bool(api_kwargs['stream'])
+        del api_kwargs['stream']
 
-    call: dict[str, Any] = {'messages': messages, **api_kwargs}
+    actual_api_kwargs = {key: value for key, value in api_kwargs.items() if value is not None}
+
     if api_dict is not None and api_dict.get('api_base'):
-        call['api_base'] = api_dict['api_base']
+        litellm_model = f"openai/{model}"
+        actual_api_kwargs['api_base'] = api_dict['api_base']
         if api_dict.get('api_key'):
-            call['api_key'] = api_dict['api_key']
-        call['model'] = f"openai/{model}"
+            actual_api_kwargs['api_key'] = api_dict['api_key']
     else:
-        call['model'] = model
-
-    def _read_usage(usage):
-        n_out = getattr(usage, 'completion_tokens', None)
-        det = getattr(usage, 'completion_tokens_details', None)
-        if n_out is not None and det is not None and getattr(det, 'reasoning_tokens', None):
-            n_out += det.reasoning_tokens
-        n_in = getattr(usage, 'prompt_tokens', None)
-        pdet = getattr(usage, 'prompt_tokens_details', None)
-        n_cached = getattr(pdet, 'cached_tokens', None) if pdet is not None else None
-        return n_out, n_in, n_cached
+        litellm_model = model
 
     message = ''
-    num_tokens = input_tokens = cached_tokens = None
+    num_tokens = None
+    input_tokens = None
+    cached_tokens = None
     if stream:
-        call['stream'] = True
-        call['stream_options'] = {'include_usage': True}
-        for chunk in litellm.completion(**call):
-            if chunk.choices and getattr(chunk.choices[0].delta, 'content', None):
+        response = litellm.completion(
+            model=litellm_model,
+            messages=messages,
+            stream=True,
+            stream_options={'include_usage': True},
+            **actual_api_kwargs
+        )
+        for chunk in response:
+            if chunk.choices and len(chunk.choices) > 0 and chunk.choices[0].delta.content is not None:
                 message += chunk.choices[0].delta.content
-            if getattr(chunk, 'usage', None) is not None:
-                num_tokens, input_tokens, cached_tokens = _read_usage(chunk.usage)
+            if chunk.usage is not None:
+                num_tokens = chunk.usage.completion_tokens
+                if hasattr(chunk.usage, 'completion_tokens_details') and chunk.usage.completion_tokens_details is not None:
+                    reasoning_tokens = getattr(chunk.usage.completion_tokens_details, 'reasoning_tokens', None)
+                    if num_tokens is not None and reasoning_tokens is not None:
+                        num_tokens += reasoning_tokens
+                input_tokens = chunk.usage.prompt_tokens
+                if hasattr(chunk.usage, 'prompt_tokens_details') and chunk.usage.prompt_tokens_details is not None:
+                    cached_tokens = chunk.usage.prompt_tokens_details.cached_tokens
     else:
-        resp = litellm.completion(**call)
-        message = resp.choices[0].message.content
-        if getattr(resp, 'usage', None) is not None:
-            num_tokens, input_tokens, cached_tokens = _read_usage(resp.usage)
+        response = litellm.completion(
+            model=litellm_model,
+            messages=messages,
+            stream=False,
+            **actual_api_kwargs
+        )
+        message = response.choices[0].message.content
+        if response.usage is not None:
+            num_tokens = response.usage.completion_tokens
+            if hasattr(response.usage, 'completion_tokens_details') and response.usage.completion_tokens_details is not None:
+                reasoning_tokens = getattr(response.usage.completion_tokens_details, 'reasoning_tokens', None)
+                if num_tokens is not None and reasoning_tokens is not None:
+                    num_tokens += reasoning_tokens
+            input_tokens = response.usage.prompt_tokens
+            if hasattr(response.usage, 'prompt_tokens_details') and response.usage.prompt_tokens_details is not None:
+                cached_tokens = response.usage.prompt_tokens_details.cached_tokens
 
     if message is None or message == '':
         raise Exception("No message returned from litellm")

--- a/livebench/run_livebench.py
+++ b/livebench/run_livebench.py
@@ -61,6 +61,7 @@ class LiveBenchParams:
     question_id: list[str] | None = None
     livebench_release_option: str | None = None
     stream: bool = False
+    use_litellm: bool = False
     remove_existing_judgment_file: bool = False
     ignore_missing_answers: bool = False
     debug: bool = False
@@ -102,6 +103,7 @@ class LiveBenchParams:
             question_id=args.question_id,
             livebench_release_option=args.livebench_release_option,
             stream=args.stream,
+            use_litellm=args.use_litellm,
             remove_existing_judgment_file=args.remove_existing_judgment_file,
             ignore_missing_answers=args.ignore_missing_answers,
             debug=args.debug,
@@ -226,6 +228,7 @@ def build_run_command(
     question_id: list[str] | None = None,
     livebench_release_option: str | None = None,
     stream: bool = False,
+    use_litellm: bool = False,
     remove_existing_judgment_file: bool = False,
     ignore_missing_answers: bool = False,
     debug: bool = False,
@@ -299,6 +302,8 @@ def build_run_command(
         gen_judge_cmd += f" --livebench-release-option {livebench_release_option}"
     if stream:
         gen_api_cmd += " --stream"
+    if use_litellm:
+        gen_api_cmd += " --use-litellm"
     if remove_existing_judgment_file:
         gen_judge_cmd += " --remove-existing-file"
     if ignore_missing_answers:
@@ -349,6 +354,7 @@ def build_run_command_from_params(params: LiveBenchParams, bench_name: str | lis
         question_id=params.question_id,
         livebench_release_option=params.livebench_release_option,
         stream=params.stream,
+        use_litellm=params.use_litellm,
         remove_existing_judgment_file=params.remove_existing_judgment_file,
         only_incorrect=params.only_incorrect,
         ignore_missing_answers=params.ignore_missing_answers,
@@ -493,6 +499,7 @@ def main():
     parser.add_argument("--question-id", nargs="+", help="Specific question IDs to process")
     parser.add_argument("--livebench-release-option", help="LiveBench release option")
     parser.add_argument("--stream", action="store_true", help="Enable streaming mode")
+    parser.add_argument("--use-litellm", action="store_true", help="Route requests through LiteLLM instead of per-provider clients")
     parser.add_argument("--remove-existing-judgment-file", action="store_true",
                       help="Remove existing judgment file before running")
     parser.add_argument("--only-incorrect", action="store_true",

--- a/livebench/scripts/spend_report.py
+++ b/livebench/scripts/spend_report.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Total API spend per task and per run from model_answer/<model>.jsonl files.
 
 Usage:
@@ -10,12 +9,9 @@ import argparse
 import glob
 import json
 import os
-import sys
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from livebench.model.api_model_config import get_model_config
-
-DATA_ROOT = os.path.join(os.path.dirname(__file__), '..', 'data')
+from livebench.common import LIVE_BENCH_ROOT_PATH
+from livebench.model import get_model_config
 
 
 def load_price(model: str):
@@ -32,19 +28,19 @@ def load_price(model: str):
 
 
 def main():
-    ap = argparse.ArgumentParser(description="Total API spend for a model's run")
-    ap.add_argument('--model', required=True, help='model display name (e.g. minimax-m2.7)')
-    ap.add_argument('--bench-name', default='live_bench',
-                    help='subtree to scan, e.g. live_bench or live_bench/math (default: live_bench)')
-    ap.add_argument('--active-only', action='store_true',
-                    help='count only questions with empty livebench_removal_date')
-    args = ap.parse_args()
+    parser = argparse.ArgumentParser(description="Total API spend for a model's run")
+    parser.add_argument('--model', required=True, help='model display name (e.g. minimax-m2.7)')
+    parser.add_argument('--bench-name', default='live_bench',
+                        help='subtree to scan, e.g. live_bench or live_bench/math (default: live_bench)')
+    parser.add_argument('--active-only', action='store_true',
+                        help='count only questions with empty livebench_removal_date')
+    args = parser.parse_args()
 
     price = load_price(args.model)
     in_price, cached_price, out_price = price if price else (None, None, None)
 
     model_file = f'{args.model.lower()}.jsonl'
-    pattern = os.path.join(DATA_ROOT, args.bench_name, '**', 'model_answer', model_file)
+    pattern = str(LIVE_BENCH_ROOT_PATH / 'data' / args.bench_name / '**' / 'model_answer' / model_file)
     answer_files = sorted(glob.glob(pattern, recursive=True))
     if not answer_files:
         print(f'No answer files for {args.model} under {args.bench_name}')
@@ -85,7 +81,7 @@ def main():
             if c is None and price is not None:
                 cached = min(ct, it)
                 uncached = max(it - cached, 0)
-                c = (uncached / 1e6) * in_price + (cached / 1e6) * cached_price + (ot / 1e6) * out_price
+                c = (uncached / 1_000_000) * in_price + (cached / 1_000_000) * cached_price + (ot / 1_000_000) * out_price
                 if not it:
                     partial += 1
             cost += (c or 0.0)

--- a/livebench/scripts/spend_report.py
+++ b/livebench/scripts/spend_report.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Total API spend per task and per run from model_answer/<model>.jsonl files.
+
+Usage:
+    python scripts/spend_report.py --model minimax-m2.7
+    python scripts/spend_report.py --model minimax-m2.7 --bench-name live_bench/math
+    python scripts/spend_report.py --model minimax-m2.7 --active-only
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from livebench.model.api_model_config import get_model_config
+
+DATA_ROOT = os.path.join(os.path.dirname(__file__), '..', 'data')
+
+
+def load_price(model: str):
+    """Return (input, cached_input, output) USD per 1M tokens, or None."""
+    try:
+        cfg = get_model_config(model)
+        cpm = getattr(cfg, 'cost_per_million', None)
+    except Exception:
+        cpm = None
+    if not cpm:
+        return None
+    in_p = float(cpm.get('input', 0))
+    return in_p, float(cpm.get('cached_input', in_p)), float(cpm.get('output', 0))
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Total API spend for a model's run")
+    ap.add_argument('--model', required=True, help='model display name (e.g. minimax-m2.7)')
+    ap.add_argument('--bench-name', default='live_bench',
+                    help='subtree to scan, e.g. live_bench or live_bench/math (default: live_bench)')
+    ap.add_argument('--active-only', action='store_true',
+                    help='count only questions with empty livebench_removal_date')
+    args = ap.parse_args()
+
+    price = load_price(args.model)
+    in_price, cached_price, out_price = price if price else (None, None, None)
+
+    model_file = f'{args.model.lower()}.jsonl'
+    pattern = os.path.join(DATA_ROOT, args.bench_name, '**', 'model_answer', model_file)
+    answer_files = sorted(glob.glob(pattern, recursive=True))
+    if not answer_files:
+        print(f'No answer files for {args.model} under {args.bench_name}')
+        return
+
+    def active_ids(answer_file):
+        qf = os.path.join(os.path.dirname(os.path.dirname(answer_file)), 'question.jsonl')
+        ids = set()
+        if os.path.exists(qf):
+            for line in open(qf):
+                if line.strip():
+                    q = json.loads(line)
+                    if q.get('livebench_removal_date', '') == '':
+                        ids.add(q['question_id'])
+        return ids
+
+    grand = {'cost': 0.0, 'in_tok': 0, 'out_tok': 0, 'n': 0, 'partial': 0}
+    rows = []
+    for af in answer_files:
+        task = af.split('/data/')[-1].rsplit('/model_answer/', 1)[0]
+        keep = active_ids(af) if args.active_only else None
+        in_tok = out_tok = n = partial = 0
+        cost = 0.0
+        for line in open(af):
+            if not line.strip():
+                continue
+            r = json.loads(line)
+            if keep is not None and r.get('question_id') not in keep:
+                continue
+            n += 1
+            it = r.get('total_input_tokens') or 0
+            ct = r.get('total_cached_tokens') or 0
+            ot = r.get('total_output_tokens') or 0
+            ot = ot if ot > 0 else 0
+            in_tok += it
+            out_tok += ot
+            c = r.get('cost_usd')
+            if c is None and price is not None:
+                cached = min(ct, it)
+                uncached = max(it - cached, 0)
+                c = (uncached / 1e6) * in_price + (cached / 1e6) * cached_price + (ot / 1e6) * out_price
+                if not it:
+                    partial += 1
+            cost += (c or 0.0)
+        if n == 0:
+            continue
+        rows.append((task, n, in_tok, out_tok, cost, partial))
+        grand['cost'] += cost
+        grand['in_tok'] += in_tok
+        grand['out_tok'] += out_tok
+        grand['n'] += n
+        grand['partial'] += partial
+
+    rows.sort(key=lambda x: -x[4])
+    print(f"\nSpend report for {args.model}"
+          + (f"  (price: ${in_price}/1M in, ${out_price}/1M out)" if price else "  (no price in config)"))
+    print(f"{'task':<42}{'n':>5}{'in_tok':>12}{'out_tok':>12}{'cost_usd':>12}")
+    print('-' * 83)
+    for task, n, it, ot, cost, partial in rows:
+        flag = ' *' if partial else ''
+        print(f"{task:<42}{n:>5}{it:>12,}{ot:>12,}{cost:>12.4f}{flag}")
+    print('-' * 83)
+    print(f"{'TOTAL':<42}{grand['n']:>5}{grand['in_tok']:>12,}{grand['out_tok']:>12,}{grand['cost']:>12.4f}")
+    if grand['partial']:
+        print(f"\n* {grand['partial']} answers had no input-token data (predate cost tracking) -> "
+              f"cost is OUTPUT-ONLY for those; total is a lower bound.")
+    if price is None:
+        print("\nNo cost_per_million in the model config; add it to compute spend.")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Add per-request spend tracking (input/cached/output tokens + `cost_usd`) on every answer record, computed from a new `cost_per_million` field in the model config.
- Add `--use-litellm` flag that routes the non-agentic tasks through LiteLLM

