### PR TITLE
Track Gemini cached tokens for cost accounting

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -110,6 +110,8 @@ class LitellmModel:
                 result['output_tokens'] = response.usage_metadata.candidates_token_count
             if response.usage_metadata.thoughts_token_count is not None:
                 result['output_tokens'] += response.usage_metadata.thoughts_token_count
+            if response.usage_metadata.cached_content_token_count is not None:
+                result['cached_tokens'] = response.usage_metadata.cached_content_token_count
 
         return result
 


### PR DESCRIPTION
## Summary

- Read `cached_content_token_count` from Gemini's usage metadata to track cached input tokens
- Enables accurate cost calculation when Gemini context caching is active

## Test plan

- [x] Verified cached token field is populated for Gemini models with repeated prompts
- [x] No change for non-Gemini providers (field simply absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)