### PR TITLE
Fix category parsing and instruction-following deduplication

### DIFF
--- a/livebench/common.py
+++ b/livebench/common.py
@@ -121,7 +121,7 @@ def get_categories_tasks(bench_name: str):
 
     else:
         # specify a category or task
-        category_name = split_bench_name[1].split('_')[0]
+        category_name = split_bench_name[1]
 
         categories = {category_name: get_hf_dataset(category_name)}
 

--- a/livebench/gen_ground_truth_judgment.py
+++ b/livebench/gen_ground_truth_judgment.py
@@ -446,7 +446,11 @@ def gen_judgments(
         nltk.download('averaged_perceptron_tagger')
         
         # Get questions for this category
-        if_questions = list(set([m.question for m in old_instruction_following_matches]))
+        # Deduplicate by question_id since m.question is a dict (unhashable)
+        seen = {}
+        for m in old_instruction_following_matches:
+            seen[m.question["question_id"]] = m.question
+        if_questions = list(seen.values())
         task_name = if_questions[0]['task']
 
         for m in model_answers:


### PR DESCRIPTION
## Summary

Fixes #416.

This PR fixes two issues encountered when running the HuggingFace question-source path locally with `run_livebench.py`:

- Preserve multi-word category names such as `data_analysis` and `instruction_following`.
- Deduplicate instruction-following questions by `question_id` instead of calling `set()` on dict objects.

## Changes

- Remove `.split('_')[0]` from category name parsing in `get_categories_tasks()`.
- Replace `set()`-based deduplication with `question_id`-based deduplication in `gen_judgments()`.

## Verification

Verified locally with:

- Model: `Qwen/Qwen3-4B-Instruct-2507`
- Backend: local vLLM OpenAI-compatible API
- LiveBench release: `2026-01-08`

The evaluation proceeds past the previously reported failures.