### PR TITLE
Add validate_eval.py for error rate reporting

### DIFF
--- a/livebench/gen_ground_truth_judgment.py
+++ b/livebench/gen_ground_truth_judgment.py
@@ -193,7 +193,7 @@ def play_a_match_gt(match: MatchSingle, output_file: str | None = None, debug=Fa
                 else:
                     # Note: agentic_coding typically uses batch processing in gen_judgments
                     # This single-question path wraps the question/answer in lists
-                    eval_result = agentic_coding_process_results([question], [answer], debug)
+                    eval_result, _ = agentic_coding_process_results([question], [answer], debug)
                     # If the question was skipped due to infrastructure error, return None
                     # to signal that judgment should not be written
                     if question['question_id'] not in eval_result:
@@ -396,26 +396,35 @@ def gen_judgments(
                 # Run evaluation (with internal retry logic)
                 model_questions = [m.question for m in model_matches]
                 answers = [m.answer for m in model_matches]
-                eval_result = agentic_coding_process_results(model_questions, answers, debug=debug, max_workers=parallel)
+                eval_result, eval_metadata = agentic_coding_process_results(model_questions, answers, debug=debug, max_workers=parallel)
                 
                 # Write final results
                 for question_id in sorted(eval_result.keys()):
                     model_answer = model_answers[model_id][question_id]
                     question = [q for q in model_questions if q['question_id'] == question_id][0]
+                    meta = eval_metadata.get(question_id, {})
                     result = {
                         "question_id": question_id,
                         "task": question['task'],
                         "model": model_id,
                         "score": eval_result[question_id],
+                        "eval_status": meta.get("eval_status", ""),
                         "tstamp": time.time(),
                         "category": "agentic_coding",
                     }
                     if "answer_id" in model_answer:
                         result["answer_id"] = model_answer["answer_id"]
+                    if "run_id" in model_answer:
+                        result["run_id"] = model_answer["run_id"]
+                    if meta.get("eval_id"):
+                        result["eval_id"] = meta["eval_id"]
+                    if meta.get("error_msg"):
+                        result["error_msg"] = meta["error_msg"]
 
                     print(
                         f"question: {question_id}, model: {model_id}, "
-                        f"score: {eval_result[question_id]}, ")
+                        f"score: {eval_result[question_id]}, "
+                        f"eval_status: {meta.get('eval_status', '')}")
                     
                     # Find the output file for this question
                     if '_output_file' in question:

--- a/livebench/process_results/coding/utils.py
+++ b/livebench/process_results/coding/utils.py
@@ -220,6 +220,29 @@ def _check_logs_for_retry_patterns(
     return retry_needed
 
 
+
+def _classify_eval_status(report_file, fix_log_file=None):
+    if not report_file.exists():
+        return "unresolved", ""
+    try:
+        r = json.load(open(report_file))
+    except Exception:
+        return "unresolved", ""
+
+    if r.get("valid", True):
+        return "unresolved", ""
+
+    err = r.get("error_msg", "")
+    fr = r.get("fix_patch_result", {})
+    fix_total = fr.get("passed_count", 0) + fr.get("failed_count", 0) + fr.get("skipped_count", 0)
+
+    if fix_total == 0:
+        if fix_log_file and fix_log_file.exists() and fix_log_file.stat().st_size > 0:
+            return "patch_error", err
+        return "eval_timeout", err
+    return "unresolved", err
+
+
 def _run_evaluation_subprocess(
     questions: list[dict],
     answers: list[dict],
@@ -357,13 +380,20 @@ def _run_evaluation_subprocess(
         if instance_id not in report['submitted_ids']:
             print(f"Instance {instance_id} not found in report (question {question_id})")
             result[question_id] = 0
+            instance_map[question_id]["eval_status"] = "not_submitted"
         elif instance_id in report['error_ids'] or instance_id in report['incomplete_ids']:
-            # Skip questions with infrastructure errors - don't include in result
-            # This signals that grading should be re-run for these questions
-            print(f"Skipping question {question_id} ({instance_id}) due to infrastructure error")
+            print(f"Skipping {question_id} ({instance_id}) - infrastructure error")
+            instance_map[question_id]["eval_status"] = "eval_error"
             continue
+        elif instance_id in report['resolved_ids']:
+            result[question_id] = 1
+            instance_map[question_id]["eval_status"] = "resolved"
         else:
-            result[question_id] = 1 if instance_id in report['resolved_ids'] else 0
+            result[question_id] = 0
+            status, err = _classify_eval_status(report_file, fix_log_file)
+            instance_map[question_id]["eval_status"] = status
+            if err:
+                instance_map[question_id]["error_msg"] = err
 
         if debug and result.get(question_id) == 0:
             if instance_id in report['unresolved_ids']:
@@ -421,11 +451,10 @@ def _run_evaluation_subprocess(
     return result, instance_map
 
 
-# python agentic_code_runner/eval/harness/run_evaluation.py --config agentic_code_runner/eval/config.json
-def agentic_coding_process_results(questions: list[dict], answers: list[dict], debug=False, max_workers=1, only_build_image=False) -> dict[str, int]:
+def agentic_coding_process_results(questions: list[dict], answers: list[dict], debug=False, max_workers=1, only_build_image=False) -> tuple[dict[str, int], dict[str, dict]]:
 
     if len(answers) == 0:
-        return dict()
+        return dict(), dict()
     
     # Initial evaluation
     result, instance_map = _run_evaluation_subprocess(questions, answers, debug, max_workers, only_build_image)
@@ -501,4 +530,20 @@ def agentic_coding_process_results(questions: list[dict], answers: list[dict], d
             # Update instance_map with new paths for next iteration
             instance_map.update(retry_instance_map)
     
-    return result
+    eval_metadata = {}
+    answers_by_qid = {a['question_id']: a for a in answers}
+    for q in questions:
+        qid = q['question_id']
+        info = instance_map.get(qid, {})
+        meta = {
+            "eval_status": info.get("eval_status", "unknown"),
+            "eval_id": info.get("eval_id", ""),
+            "instance_id": info.get("instance_id", ""),
+        }
+        if info.get("error_msg"):
+            meta["error_msg"] = info["error_msg"]
+        if qid in answers_by_qid and "run_id" in answers_by_qid[qid]:
+            meta["run_id"] = answers_by_qid[qid]["run_id"]
+        eval_metadata[qid] = meta
+
+    return result, eval_metadata

--- a/livebench/scripts/check_grading_flakiness.py
+++ b/livebench/scripts/check_grading_flakiness.py
@@ -108,7 +108,7 @@ def grade_ground_truth(bench_name: str, question_ids: list[str] | None, question
     
     # Process results and get scores
     max_workers = parallel if parallel else 1
-    result = agentic_coding_process_results(questions, gt_answers, debug=True, max_workers=max_workers)
+    result, _ = agentic_coding_process_results(questions, gt_answers, debug=True, max_workers=max_workers)
     
     print(f"Evaluation complete. Results: {len(result)} question(s)")
     

--- a/livebench/scripts/validate_eval.py
+++ b/livebench/scripts/validate_eval.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+Validate LiveBench evaluation results for a model.
+
+Reports answer-generation errors, eval errors, and total error rates
+per task, category, and overall. Returns exit code 1 if any category
+exceeds the error threshold.
+
+Usage:
+    python scripts/validate_eval.py --model minimax-m3
+    python scripts/validate_eval.py --model minimax-m3 --threshold 5
+    python scripts/validate_eval.py --model minimax-m3 --category agentic_coding
+"""
+
+import argparse
+import json
+import glob
+import os
+import sys
+
+CATEGORIES = [
+    "coding", "data_analysis", "instruction_following",
+    "language", "math", "reasoning", "agentic_coding",
+]
+
+ANSWER_ERROR = "$ERROR$"
+
+# Infrastructure failures only — things that prevent reliable scoring.
+# api_error excluded: it's the judgment echo of $ERROR$ in the answer file.
+# patch_error excluded: model produced a malformed patch — that's a wrong answer, not infra.
+EVAL_FAILURE_STATUSES = {
+    "eval_error", "eval_timeout",
+    "eval_flaky", "eval_no_fix", "eval_missing_tests",
+}
+
+
+def collect_answer_errors(data_root, model, categories):
+    """Count $ERROR$ answers per task."""
+    results = {}
+    for cat in categories:
+        pattern = os.path.join(data_root, cat, "*", "model_answer", f"{model}.jsonl")
+        for f in sorted(glob.glob(pattern)):
+            task = f.split(os.sep)[-3]
+            key = f"{cat}/{task}"
+            total = 0
+            errors = 0
+            answer_details = {}
+            for line in open(f):
+                d = json.loads(line)
+                total += 1
+                if d["choices"][0]["turns"][0] == ANSWER_ERROR:
+                    errors += 1
+                    err_msg = d.get("error_msg", d.get("error", "unknown"))
+                    answer_details[err_msg] = answer_details.get(err_msg, 0) + 1
+            results[key] = {"total": total, "answer_errors": errors, "answer_details": answer_details}
+    return results
+
+
+def collect_eval_errors(data_root, model, categories):
+    """Count eval failures from judgment files."""
+    results = {}
+    for cat in categories:
+        pattern = os.path.join(data_root, cat, "*", "model_judgment", "ground_truth_judgment.jsonl")
+        for f in sorted(glob.glob(pattern)):
+            task = f.split(os.sep)[-3]
+            key = f"{cat}/{task}"
+            eval_errors = 0
+            eval_details = {}
+            for line in open(f):
+                d = json.loads(line)
+                if d.get("model") != model:
+                    continue
+                status = d.get("eval_status", "")
+                if status in EVAL_FAILURE_STATUSES:
+                    eval_errors += 1
+                    eval_details[status] = eval_details.get(status, 0) + 1
+            if key not in results:
+                results[key] = {}
+            results[key]["eval_errors"] = eval_errors
+            results[key]["eval_details"] = eval_details
+    return results
+
+
+def merge_results(answer_results, eval_results):
+    """Merge answer and eval error counts."""
+    all_keys = sorted(set(list(answer_results.keys()) + list(eval_results.keys())))
+    merged = {}
+    for key in all_keys:
+        a = answer_results.get(key, {})
+        e = eval_results.get(key, {})
+        total = a.get("total", 0)
+        ans_err = a.get("answer_errors", 0)
+        eval_err = e.get("eval_errors", 0)
+        all_err = ans_err + eval_err
+        rate = (all_err / total * 100) if total > 0 else 0
+        details = {}
+        for k, v in a.get("answer_details", {}).items():
+            details[k] = details.get(k, 0) + v
+        for k, v in e.get("eval_details", {}).items():
+            details[k] = details.get(k, 0) + v
+        merged[key] = {
+            "total": total,
+            "answer_errors": ans_err,
+            "eval_errors": eval_err,
+            "all_errors": all_err,
+            "rate": rate,
+            "details": details,
+        }
+    return merged
+
+
+def print_report(merged, threshold):
+    """Print the validation report."""
+    # Task-level
+    print(f"{'Task':<50} {'Total':>6} {'Ans':>5} {'Eval':>5} {'All':>5} {'Rate':>7}  Status")
+    print("-" * 95)
+
+    cat_totals = {}
+    overall = {"total": 0, "answer_errors": 0, "eval_errors": 0, "all_errors": 0}
+    needs_retry = False
+
+    for key in sorted(merged):
+        r = merged[key]
+        cat = key.split("/")[0]
+        status = "RETRY" if r["rate"] > threshold else "OK"
+
+        if cat not in cat_totals:
+            cat_totals[cat] = {"total": 0, "answer_errors": 0, "eval_errors": 0, "all_errors": 0, "details": {}}
+        for field in ["total", "answer_errors", "eval_errors", "all_errors"]:
+            cat_totals[cat][field] += r[field]
+            overall[field] += r[field]
+        for k, v in r["details"].items():
+            cat_totals[cat]["details"][k] = cat_totals[cat]["details"].get(k, 0) + v
+
+        detail = ""
+        if r["details"]:
+            detail = " (" + ", ".join(f"{v}x {k}" for k, v in sorted(r["details"].items())) + ")"
+
+        if r["all_errors"] > 0:
+            print(f"  {key:<48} {r['total']:>6} {r['answer_errors']:>5} {r['eval_errors']:>5} {r['all_errors']:>5} {r['rate']:>6.1f}%  {status}{detail}")
+
+    # Category-level
+    print()
+    print(f"{'Category':<50} {'Total':>6} {'Ans':>5} {'Eval':>5} {'All':>5} {'Rate':>7}  Status")
+    print("-" * 95)
+    for cat in sorted(cat_totals):
+        c = cat_totals[cat]
+        rate = (c["all_errors"] / c["total"] * 100) if c["total"] > 0 else 0
+        status = "RETRY" if rate > threshold else "OK"
+        if rate > threshold:
+            needs_retry = True
+        detail = ""
+        if c["details"]:
+            detail = " (" + ", ".join(f"{v}x {k}" for k, v in sorted(c["details"].items())) + ")"
+        print(f"  {cat:<48} {c['total']:>6} {c['answer_errors']:>5} {c['eval_errors']:>5} {c['all_errors']:>5} {rate:>6.1f}%  {status}{detail}")
+
+    # Overall
+    print()
+    overall_rate = (overall["all_errors"] / overall["total"] * 100) if overall["total"] > 0 else 0
+    print(f"  {'OVERALL':<48} {overall['total']:>6} {overall['answer_errors']:>5} {overall['eval_errors']:>5} {overall['all_errors']:>5} {overall_rate:>6.1f}%")
+
+    return needs_retry
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate LiveBench evaluation results")
+    parser.add_argument("--model", required=True, help="Model name")
+    parser.add_argument("--threshold", type=float, default=10.0, help="Error rate threshold (default: 10%%)")
+    parser.add_argument("--category", nargs="+", default=None, help="Categories to check (default: all)")
+    parser.add_argument("--data-root", default="data/live_bench", help="Path to data root")
+    args = parser.parse_args()
+
+    categories = args.category if args.category else CATEGORIES
+    categories = [c for c in categories if os.path.isdir(os.path.join(args.data_root, c))]
+
+    print(f"Validating {args.model} (threshold: {args.threshold}%)")
+    print()
+
+    answer_results = collect_answer_errors(args.data_root, args.model, categories)
+    eval_results = collect_eval_errors(args.data_root, args.model, categories)
+    merged = merge_results(answer_results, eval_results)
+
+    needs_retry = print_report(merged, args.threshold)
+
+    print()
+    if needs_retry:
+        print("RESULT: RETRY NEEDED — one or more categories exceed %.1f%% error rate" % args.threshold)
+        sys.exit(1)
+    else:
+        print("RESULT: ALL OK — all categories below %.1f%% error rate" % args.threshold)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add `scripts/validate_eval.py` that reports answer-generation and eval infrastructure error rates per task and category.

### Usage

```bash
python scripts/validate_eval.py --model minimax-m3
python scripts/validate_eval.py --model minimax-m3 --threshold 10
python scripts/validate_eval.py --model minimax-m3 --category agentic_coding
```

### Output

```
Task                                    Total   Ans  Eval   All    Rate  Status
agentic_coding/typescript                  20     3     0     3   15.0%  RETRY (3x Agent killed before submission)
instruction_following/story_generation     50     2     0     2    4.0%  OK (2x No message returned from litellm)

Category                                Total   Ans  Eval   All    Rate  Status
agentic_coding                             60     3     0     3    5.0%  OK
instruction_following                     200     3     0     3    1.5%  OK
OVERALL                                  1258     9     0     9    0.7%
```

### Error classification

- **Ans errors**: `$ERROR$` in answer files (API failures, empty responses)
- **Eval errors**: `eval_timeout`, `eval_error`, `eval_flaky`, `eval_no_fix`, `eval_missing_tests` in judgment files
- `api_error` excluded from eval count (it's the judgment echo of `$ERROR$`)
- `patch_error` excluded (model produced bad patch — wrong answer, not infra)

Exit code 1 if any category exceeds threshold. Used by the on-demand VM workflow to trigger retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)