### PR TITLE
Bound agentic litellm requests with a default timeout

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -352,6 +352,9 @@ class LitellmModel:
                 actual_kwargs['thinking'] = {'type': 'disabled'}
         if actual_kwargs.get('stream', False) and 'stream_options' not in actual_kwargs:
             actual_kwargs['stream_options'] = {'include_usage': True}
+        # Bound the request so a black-holed connection can't hang an agent
+        # indefinitely; on timeout the @retry above reconnects on a fresh socket.
+        actual_kwargs.setdefault('timeout', 600)
         try:
             res = litellm.completion(
                 model=self.config.model_name, messages=messages, **actual_kwargs
@@ -409,8 +412,14 @@ class LitellmModel:
                 system_messages.append(message.get('content', ''))
         system_prompt = system_messages[0] if system_messages else None
 
+        # Bound the request so a black-holed connection can't hang an agent
+        # indefinitely. A Cloudflare 5xx episode once pinned agents for 30+ min
+        # in a blocking ssl.read with no timeout; on timeout the @retry above
+        # reconnects on a fresh socket.
+        responses_kwargs = self.config.model_kwargs | kwargs
+        responses_kwargs.setdefault('timeout', 600)
         res = litellm.responses(
-            model=self.config.model_name, input=messages, instructions=system_prompt, **(self.config.model_kwargs | kwargs),
+            model=self.config.model_name, input=messages, instructions=system_prompt, **responses_kwargs,
         )
 
         output_text = ""


### PR DESCRIPTION
## Problem

The agentic model path (`_query_responses` / `_query_completion` in `litellm_model.py`) called `litellm.responses()` / `litellm.completion()` with **no request timeout**, so a black-holed connection could hang an agent thread indefinitely.

Observed during a `kindle-alpha-xhigh` eval: a Cloudflare 5xx episode left 3 agent threads stuck **30+ minutes** in a blocking `ssl.read` on dead sockets (`py-spy` showed `ssl.read → httpcore → litellm.responses`). No retry loop was running — the reads simply never returned. The only recovery was killing the TCP connections out from under the process (`ss -K`), after which tenacity retried on fresh sockets.

## Fix

Default `timeout` to **600s** (matching the non-agentic `chat_completion_litellm` path in `completions.py`) in both agentic query methods. On timeout, the existing `@retry` decorator reconnects on a fresh socket. Uses `setdefault()` so an explicit per-model `timeout` in config still wins.

Minimal change, no behavior change on the happy path.