### PR TITLE
Add glm-5.2 model config

### DIFF
--- a/livebench/model/model_configs/zai.yml
+++ b/livebench/model/model_configs/zai.yml
@@ -124,3 +124,27 @@ api_kwargs:
       thinking:
         type: enabled
 preserve_reasoning: true
+---
+display_name: glm-5.2
+api_name:
+  https://api.z.ai/api/paas/v4: glm-5.2
+  https://open.bigmodel.cn/api/paas/v4: glm-5.2
+  https://openrouter.ai/api/v1: z-ai/glm-5.2
+default_provider: https://open.bigmodel.cn/api/paas/v4
+api_keys:
+  https://api.z.ai/api/paas/v4: ZAI_API_KEY
+  https://open.bigmodel.cn/api/paas/v4: ZAI_API_KEY_v2
+  https://openrouter.ai/api/v1: OPENROUTER_API_KEY
+api_kwargs:
+  default:
+    temperature: 1.0
+    top_p: 0.95
+    max_tokens: 131072
+    stream: true
+    reasoning_effort: max
+    extra_body:
+      thinking:
+        type: enabled
+  https://openrouter.ai/api/v1:
+    reasoning_effort: xhigh
+preserve_reasoning: true


### PR DESCRIPTION
Adds the **glm-5.2** model config to `zai.yml` (Z.AI's GLM-5.2, released 2026-06-13).

## Config
- **Providers**: `open.bigmodel.cn` (default, `ZAI_API_KEY_v2`), `api.z.ai` (`ZAI_API_KEY`), and OpenRouter (`z-ai/glm-5.2`).
- **Reasoning**: `thinking: {type: enabled}` + `reasoning_effort: max` per the [official docs](https://docs.z.ai/guides/llm/glm-5.2). `max_tokens: 131072`, `stream: true`, `preserve_reasoning: true`.
- **Provider nuance**: OpenRouter's GLM-5.2 rejects `reasoning_effort: max` (expects `xhigh|high|...`), so a per-provider override sets `reasoning_effort: xhigh` for the OpenRouter endpoint (merges over `default`).

## Provider notes (from running the eval)
- `open.bigmodel.cn` (with `ZAI_API_KEY_v2`) handled the full eval cleanly — recommended default.
- `api.z.ai` (with the standard `ZAI_API_KEY`) rate-limited hard at every parallelism (even 12 concurrent) — usable only at very low parallel.
- OpenRouter works (no rate limits) but had some mid-stream drops on long max-effort chains.

Eval result (livebench.ai): 7-category avg **76.2** — best open-weight model.