### PR TITLE
auto-fetch stale reference clone before commit-hash check in agentic v2

### DIFF
--- a/livebench/agentic_code_runner/eval/harness/build_dataset.py
+++ b/livebench/agentic_code_runner/eval/harness/build_dataset.py
@@ -473,6 +473,8 @@ class CliArgs:
             if not git_util.exists(repo_dir):
                 self.logger.warning(f"Repository not found: {repo_dir}")
                 git_util.clone_repository(self.repo_dir / repo.org, repo.org, repo.repo)
+            else:
+                git_util.fetch_repository(repo_dir)
 
             is_clean, error_msg = git_util.is_clean(repo_dir)
             if not is_clean:

--- a/livebench/agentic_code_runner/eval/harness/run_evaluation.py
+++ b/livebench/agentic_code_runner/eval/harness/run_evaluation.py
@@ -538,6 +538,8 @@ class CliArgs:
             if not git_util.exists(repo_dir):
                 self.logger.warning(f"Repository not found: {repo_dir}")
                 git_util.clone_repository(self.repo_dir / repo.org, repo.org, repo.repo)
+            else:
+                git_util.fetch_repository(repo_dir)
 
             is_clean, error_msg = git_util.is_clean(repo_dir)
             if not is_clean:

--- a/livebench/agentic_code_runner/eval/utils/git_util.py
+++ b/livebench/agentic_code_runner/eval/utils/git_util.py
@@ -54,6 +54,13 @@ def clone_repository(destination: Path, org: str, repo: str):
     )
 
 
+def fetch_repository(repo_path: Path):
+    subprocess.run(
+        ["git", "-C", str(repo_path), "fetch", "origin"],
+        check=True,
+    )
+
+
 def get_all_commit_hashes(repo_path: Path, logger: logging.Logger) -> set[str]:
     try:
         repo = Repo(repo_path)


### PR DESCRIPTION
## Fetch the reference clone before the commit-hash check

`check_commit_hashes` (in `run_evaluation.py` / `build_dataset.py`) validates each question's `base_commit` against a local reference clone at `data/repos/<org>/<repo>`. That clone is created once (clone-if-absent) and **never re-fetched**, so a base_commit newer than the clone reads as "missing" and aborts the whole batch — even though the commit is valid upstream and is present in the per-PR image that actually runs the tests. Saw this for questions in typescript

Hit `agentic_coding_v2` TypeScript: `data/repos/vuejs/core` was pinned at **2026-05-27** while several vuejs base_commits are from **06-11** → `Commit hash not found in vuejs/core:pr-14950` → all 20 TS questions blocked. Same stale clone on gabevm and on-demand VMs (not snapshot-specific).

**Fix:** fetch existing clones before validating (clone-if-absent / else fetch). Validated on a stale `vuejs/core` clone: 3/8 base_commits missing → fetch → 0 missing.


