### PR TITLE
Fix KeyError in Gemini genai path when usage_metadata lacks token counts

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -148,6 +148,9 @@ class LitellmModel:
             'response': response,
             'content': message,
             'message': response.candidates[0].content,
+            'input_tokens': 0,
+            'output_tokens': 0,
+            'cached_tokens': 0,
         }
 
         if response.usage_metadata is not None:


### PR DESCRIPTION
## Problem
`_query_completion_generativeai` (the `gemini-3*` path) only sets `input_tokens`/`output_tokens`/`cached_tokens` **conditionally** — when the corresponding `usage_metadata` field is non-None. But:
- `query()` reads `result['input_tokens']` / `result['output_tokens']` with **bracket access** (line 544–545), and
- line 159 does `result['output_tokens'] += thoughts_token_count`.

When a Gemini response comes back without token counts (e.g. an empty/blocked completion), these raise `KeyError: 'output_tokens'`, which is an **unhandled terminating exception** — it kills the instance mid-run.

Observed on a full `gemini-3.5-flash-high` agentic_coding_v2 run: 7 instances terminated with this KeyError.

## Fix
Initialize the three token fields to `0` in the result dict, matching the other query paths (`_query_completion`, `_query_responses`, `_query_completion_anthropic_direct`) which always set them. The conditional block then overwrites/increments correctly, and `query()`'s bracket access is always safe. +3/−0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)