### PR TITLE
Harness: Responses API for non-OpenAI endpoints + Anthropic streaming robustness

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -86,6 +86,10 @@ class LitellmModel:
         self.output_tokens = 0
         self.cached_tokens = 0
         self.cache_creation_tokens = 0
+        # Stateful Responses-API chaining: only send the new turn each time
+        # (previous_response_id + store) instead of replaying the whole convo.
+        self.previous_response_id = None
+        self._responses_sent_upto = 0
         # Observability for the empty-response resampling (see _query_completion_anthropic_direct):
         # empty_responses = total empty completions seen; empty_resamples_recovered =
         # turns where a resample turned an initial empty into usable text.
@@ -540,9 +544,24 @@ class LitellmModel:
                 system_messages.append(message.get('content', ''))
         system_prompt = system_messages[0] if system_messages else None
 
+        # Stateful chaining: after the first turn send ONLY the new user/tool
+        # messages + previous_response_id (server retains prior turns incl.
+        # reasoning). Keeps each request tiny and avoids reasoning-item placement
+        # 400s from full replay. store=True retains each response for the next turn.
+        call_kwargs = dict(self.config.model_kwargs | kwargs)
+        call_kwargs['store'] = True
+        if self.previous_response_id is not None:
+            src = messages[self._responses_sent_upto:]
+            call_kwargs['previous_response_id'] = self.previous_response_id
+        else:
+            src = messages
+        input_to_send = [{'role': m['role'], 'content': m.get('content', '')}
+                         for m in src if m.get('role') in ('user', 'tool')]
         res = litellm.responses(
-            model=self.config.model_name, input=messages, instructions=system_prompt, **(self.config.model_kwargs | kwargs),
+            model=self.config.model_name, input=input_to_send, instructions=system_prompt, **call_kwargs,
         )
+        self._responses_sent_upto = len(messages)
+        self.previous_response_id = getattr(res, 'id', None)
 
         output_text = ""
 
@@ -601,7 +620,7 @@ class LitellmModel:
         elif self.config.api_type == "completion":
             result = self._query_completion(actual_messages, **kwargs)
         elif self.config.api_type == "responses":
-            result = self._query_responses(actual_messages, **kwargs)
+            result = self._query_responses(messages, **kwargs)  # raw messages: stateful chaining tracks the delta
         else:
             raise ValueError(f"Invalid API type: {self.config.api_type}")
 

--- a/livebench/gen_api_answer.py
+++ b/livebench/gen_api_answer.py
@@ -195,6 +195,13 @@ def setup_model(model_config: ModelConfig, api_dict: dict[str, str] | None = Non
                 api_dict['api_key'] = os.environ.get(model_config.api_keys[provider])
     
 
+    # Explicit api_base for a non-URL provider (e.g. openai_responses pointing at a
+    # non-OpenAI Responses endpoint such as Meta's api.meta.ai/v1).
+    if api_dict is None and getattr(model_config, 'api_base', None):
+        api_dict = {'api_base': model_config.api_base}
+        if model_config.api_keys and provider in model_config.api_keys and os.environ.get(model_config.api_keys[provider]):
+            api_dict['api_key'] = os.environ.get(model_config.api_keys[provider])
+
     api_kwargs = None
     if model_config.api_kwargs:
         api_kwargs = {}

--- a/livebench/model/api_model_config.py
+++ b/livebench/model/api_model_config.py
@@ -16,6 +16,7 @@ class ModelConfig:
     prompt_prefix: str | None = None # prefix to add to the prompt
     preserve_reasoning: bool | None = None # whether to preserve reasoning in multi-turn tasks
     cost_per_million: dict[str, float] | None = None # USD per 1M tokens; keys: input, cached_input, output
+    api_base: str | None = None # explicit base URL for the provider (e.g. non-OpenAI Responses API endpoints like Meta)
 
 @cache
 def load_model_configs(file_path: str) -> dict[str, ModelConfig]:

--- a/livebench/model/completions.py
+++ b/livebench/model/completions.py
@@ -455,6 +455,9 @@ def chat_completion_anthropic(model: str, messages: Conversation, temperature: f
         api_kwargs.update(model_api_kwargs)
 
     actual_api_kwargs = {key: (value if value is not None else NOT_GIVEN) for key, value in api_kwargs.items()}
+    # client.messages.stream() streams intrinsically; a leftover litellm `stream` kwarg would TypeError.
+    actual_api_kwargs.pop('stream', None)
+    actual_api_kwargs.pop('stream_options', None)
 
     system = [message for message in messages if message['role'] == 'system']
     if len(system) > 0:
@@ -467,7 +470,11 @@ def chat_completion_anthropic(model: str, messages: Conversation, temperature: f
     message = []
 
     client = c
-    if actual_api_kwargs.get('betas', []):
+    _thinking_cfg = actual_api_kwargs.get('thinking') or {}
+    _needs_beta = bool(actual_api_kwargs.get('betas', [])) or (
+        isinstance(_thinking_cfg, dict) and _thinking_cfg.get('type') in ('auto', 'adaptive')
+    )
+    if _needs_beta:
         client = c.beta
 
     with client.messages.stream(
@@ -522,6 +529,23 @@ def chat_completion_anthropic(model: str, messages: Conversation, temperature: f
     text_messages = [c for c in message if c['type'] == 'text' and c.get('text', '').strip()]
     if len(text_messages) == 0:
         block_types = [c['type'] for c in message]
+        if stop_reason == 'max_tokens':
+            # Token exhaustion: the entire max_tokens budget went to the thinking
+            # block, leaving no final answer. Match the litellm path -- record an
+            # empty answer + eval_status so it grades as a genuine 0 (a real model
+            # failure), not a hard infra $ERROR$. Do NOT retry-chase token limits.
+            _md: dict[str, Any] = {'eval_status': 'token_exhaustion'}
+            _out = -1
+            if final_usage is not None:
+                _out = final_usage.output_tokens
+                _md['input_tokens'] = final_usage.input_tokens
+                _cr = getattr(final_usage, 'cache_read_input_tokens', None)
+                if _cr is not None:
+                    _md['cached_tokens'] = _cr
+                _cc = getattr(final_usage, 'cache_creation_input_tokens', None)
+                if _cc is not None:
+                    _md['cache_creation'] = _cc
+            return "", _out, _md
         raise Exception(f"No response from Anthropic (stop_reason={stop_reason}, blocks={block_types})")
 
     message_text = text_messages[0]['text']
@@ -532,6 +556,9 @@ def chat_completion_anthropic(model: str, messages: Conversation, temperature: f
         cached_tokens = getattr(final_usage, 'cache_read_input_tokens', None)
         if cached_tokens is not None:
             metadata['cached_tokens'] = cached_tokens
+        cache_creation = getattr(final_usage, 'cache_creation_input_tokens', None)
+        if cache_creation is not None:
+            metadata['cache_creation'] = cache_creation
         return message_text, tokens, metadata
 
     # Fallback when usage is unavailable: approximate output tokens via count_tokens
@@ -680,6 +707,9 @@ def chat_completion_litellm(
 ) -> tuple[str, int, dict[str, Any] | None]:
     """Provider-agnostic path via LiteLLM, selected by the --use-litellm flag."""
     import litellm
+    # Anthropic long-stream reliability: litellm's default aiohttp transport drops
+    # multi-minute streams; force httpx (what the native SDK uses).
+    litellm.disable_aiohttp_transport = True
 
     api_kwargs: API_Kwargs = {
         'temperature': temperature
@@ -705,7 +735,8 @@ def chat_completion_litellm(
     litellm_provider_aliases = {'google': 'gemini', 'together': 'together_ai', 'openai_responses': 'openai/responses'}
 
     if api_dict is not None and api_dict.get('api_base'):
-        litellm_model = f"openai/{model}"
+        # honor the responses-API bridge for non-openai endpoints (provider=openai_responses)
+        litellm_model = f"{litellm_provider_aliases.get(provider, 'openai')}/{model}"
         actual_api_kwargs['api_base'] = api_dict['api_base']
         if api_dict.get('api_key'):
             actual_api_kwargs['api_key'] = api_dict['api_key']
@@ -759,34 +790,50 @@ def chat_completion_litellm(
 
     timeout = actual_api_kwargs.pop('timeout', 600)
 
-    try:
-        response = litellm.completion(
-            model=litellm_model, messages=messages, stream=stream, timeout=timeout, **actual_api_kwargs
-        )
-    except Exception as e:
-        # Fall back to non-streaming if the provider rejects streaming
-        err = str(e).lower()
-        if stream and 'stream' in err and any(s in err for s in ('support', 'invalid', 'not allowed', 'verified')):
-            logger.warning(f"{litellm_model} rejected streaming, retrying non-streaming: {e}")
-            stream = False
-            actual_api_kwargs.pop('stream_options', None)
-            response = litellm.completion(
-                model=litellm_model, messages=messages, stream=False, timeout=timeout, **actual_api_kwargs
-            )
-        else:
-            raise
+    _TRANSIENT_STREAM_ERRS = (
+        'peer closed connection', 'incomplete chunked read', 'apiconnectionerror',
+        'midstreamfallback', 'connection error', 'connection reset', 'connection aborted',
+        'server disconnected', 'timed out', 'timeout',
+    )
+    _MAX_ATTEMPTS = 3
 
-    if stream:
-        chunks = list(response)
-        last_usage = None
-        for chunk in reversed(chunks):
-            if hasattr(chunk, 'usage') and chunk.usage is not None:
-                last_usage = chunk.usage
-                break
-        response = litellm.stream_chunk_builder(chunks, messages=messages)
-        if response.usage is not None and last_usage is not None:
-            if not response.usage.prompt_tokens and getattr(last_usage, 'prompt_tokens', None):
-                response.usage.prompt_tokens = last_usage.prompt_tokens
+    def _do_litellm_call(use_stream):
+        resp = litellm.completion(
+            model=litellm_model, messages=messages, stream=use_stream, timeout=timeout,
+            num_retries=3, **actual_api_kwargs
+        )
+        if use_stream:
+            # Consume the stream HERE so a mid-stream connection drop is caught and retryable.
+            chunks = list(resp)
+            last_usage = None
+            for chunk in reversed(chunks):
+                if hasattr(chunk, 'usage') and chunk.usage is not None:
+                    last_usage = chunk.usage
+                    break
+            resp = litellm.stream_chunk_builder(chunks, messages=messages)
+            if resp.usage is not None and last_usage is not None:
+                if not resp.usage.prompt_tokens and getattr(last_usage, 'prompt_tokens', None):
+                    resp.usage.prompt_tokens = last_usage.prompt_tokens
+        return resp
+
+    response = None
+    for _attempt in range(1, _MAX_ATTEMPTS + 1):
+        try:
+            response = _do_litellm_call(stream)
+            break
+        except Exception as e:
+            err = str(e).lower()
+            # Provider rejects streaming outright -> permanently fall back to non-streaming.
+            if stream and 'stream' in err and any(s in err for s in ('support', 'invalid', 'not allowed', 'verified')):
+                logger.warning(f"{litellm_model} rejected streaming, retrying non-streaming: {e}")
+                stream = False
+                actual_api_kwargs.pop('stream_options', None)
+                continue
+            # Transient network / mid-stream drop -> retry the whole call.
+            if _attempt < _MAX_ATTEMPTS and any(s in err for s in _TRANSIENT_STREAM_ERRS):
+                logger.warning(f"{litellm_model} transient stream error (attempt {_attempt}/{_MAX_ATTEMPTS}), retrying: {e}")
+                continue
+            raise
 
     message = response.choices[0].message.content
     finish_reason = response.choices[0].finish_reason
@@ -804,8 +851,10 @@ def chat_completion_litellm(
             cached_tokens = response.usage.prompt_tokens_details.cached_tokens or 0
 
     if message is None or message == '':
-        if finish_reason == 'length' and reasoning_content:
-            logger.warning(f"Token exhaustion: model used all tokens on reasoning ({num_tokens} tokens), no content produced")
+        if finish_reason == 'length':
+            # finish_reason=length + empty content = token exhaustion, regardless of whether
+            # litellm surfaced reasoning_content (it often doesn't for Anthropic thinking).
+            logger.warning(f"Token exhaustion: model used all tokens ({num_tokens}), no content produced")
             message = ""
             token_exhaustion = True
         else:

--- a/livebench/model/model_configs/meta.yml
+++ b/livebench/model/model_configs/meta.yml
@@ -30,3 +30,40 @@ api_keys:
   https://api.fireworks.ai/inference/v1: FIREWORKS_API_KEY
 aliases:
   - llama4-maverick
+---
+# Meta muse-spark via the OpenAI Responses API (api.meta.ai/v1)
+display_name: muse-spark-1.1-high
+api_name:
+  openai_responses: muse-spark-1.1
+default_provider: openai_responses
+api_base: https://api.meta.ai/v1
+api_keys:
+  openai_responses: META_API_KEY
+api_kwargs:
+  default:
+    temperature: null
+  openai_responses:
+    max_output_tokens: null
+    timeout: 550
+    reasoning:
+      effort: high
+      summary: auto
+preserve_reasoning: true
+---
+display_name: muse-spark-1.1-xhigh
+api_name:
+  openai_responses: muse-spark-1.1
+default_provider: openai_responses
+api_base: https://api.meta.ai/v1
+api_keys:
+  openai_responses: META_API_KEY
+api_kwargs:
+  default:
+    temperature: null
+  openai_responses:
+    max_output_tokens: null
+    timeout: 550
+    reasoning:
+      effort: xhigh
+      summary: auto
+preserve_reasoning: true


### PR DESCRIPTION
Harness fixes for running reasoning models via the OpenAI **Responses API** on non-OpenAI endpoints (Meta muse-spark), plus Anthropic streaming robustness.

## Changes
**`model/completions.py`**
- Native Anthropic path (`chat_completion_anthropic`): strip leftover `stream` kwarg (native `.stream()` rejects it), use the beta client for `thinking.type` auto/adaptive, track `cache_creation` tokens, and treat `stop_reason=max_tokens` with no text as `token_exhaustion` (empty answer, graded 0) instead of a hard `$ERROR$`.
- LiteLLM path (`chat_completion_litellm`): retry the completion+stream-consumption on transient mid-stream drops (peer-closed / incomplete-chunked-read / MidStreamFallback), `num_retries=3`, `disable_aiohttp_transport` (httpx is more robust on long Anthropic streams), and classify `finish_reason=length` empties as `token_exhaustion` without requiring `reasoning_content`.
- **Responses-API routing for non-OpenAI endpoints**: when an `api_base` is set, honor `litellm_provider_aliases` so `openai_responses` → `openai/responses/<model>` (instead of always forcing chat-completions).

**`model/api_model_config.py`** + **`gen_api_answer.py`**: add an optional `api_base` field to `ModelConfig` and build `api_dict` from it in `setup_model`, so a config can point the Responses API at a non-OpenAI endpoint.

**`agentic_code_runner/.../litellm_model.py`**: agentic Responses path now uses **`previous_response_id` stateful chaining** (+ `store=True`) — sends only the new turn each step instead of replaying the whole conversation. Eliminates the reasoning-item placement 400s and keeps requests tiny (context served from cache).

**`model/model_configs/meta.yml`**: Meta muse-spark-1.1 configs (high + xhigh) via the Responses API with `reasoning.summary: auto` (gateway keepalive) + `timeout: 550`.
