### PR TITLE
validate_eval: add agentic_coding_v2, split terminal vs retryable errors

### DIFF
--- a/livebench/scripts/progress.py
+++ b/livebench/scripts/progress.py
@@ -20,7 +20,7 @@ from datetime import datetime
 
 CATEGORIES = [
     "coding", "data_analysis", "instruction_following",
-    "language", "math", "reasoning", "agentic_coding",
+    "language", "math", "reasoning", "agentic_coding", "agentic_coding_v2",
 ]
 
 ANSWER_ERROR = "$ERROR$"

--- a/livebench/scripts/validate_eval.py
+++ b/livebench/scripts/validate_eval.py
@@ -80,23 +80,54 @@ def is_terminal_error(record):
     return any(p in text for p in TERMINAL_ERROR_PATTERNS)
 
 
+def load_active_questions(task_dir):
+    """Question ids that are currently live for a task, or None if unknown.
+
+    Answer/judgment files keep records for questions that have since been
+    removed from the benchmark; those are never re-run, so their errors must
+    not count toward retry decisions (or the denominator).
+    """
+    qfile = os.path.join(task_dir, "question.jsonl")
+    if not os.path.exists(qfile):
+        return None
+    active = set()
+    for line in open(qfile):
+        q = json.loads(line)
+        if not q.get("livebench_removal_date"):
+            active.add(q.get("question_id"))
+    return active
+
+
 def collect_answer_errors(data_root, model, categories):
-    """Count $ERROR$ answers per task, split transient vs terminal."""
+    """Count $ERROR$ answers per task, split transient vs terminal.
+
+    Answer files can accumulate records across reruns; only the latest
+    record (by tstamp) per question is counted, so totals reflect the
+    number of questions answered, not the number of attempts.
+    """
     results = {}
     for cat in categories:
         pattern = os.path.join(data_root, cat, "*", "model_answer", f"{model}.jsonl")
         for f in sorted(glob.glob(pattern)):
             task = f.split(os.sep)[-3]
             key = f"{cat}/{task}"
-            total = 0
+            active = load_active_questions(os.path.dirname(os.path.dirname(f)))
+            latest = {}
+            for line in open(f):
+                d = json.loads(line)
+                qid = d.get("question_id")
+                if active is not None and qid not in active:
+                    continue
+                prev = latest.get(qid)
+                if prev is None or d.get("tstamp", 0) >= prev.get("tstamp", 0):
+                    latest[qid] = d
+            total = len(latest)
             errors = 0
             terminal = 0
             answer_details = {}
-            for line in open(f):
-                d = json.loads(line)
-                total += 1
+            for d in latest.values():
                 if d["choices"][0]["turns"][0] == ANSWER_ERROR:
-                    err_msg = str(d.get("error_msg", d.get("error", "unknown")))[:DETAIL_KEY_MAX]
+                    err_msg = str(d.get("error_msg") or d.get("error") or "unknown")[:DETAIL_KEY_MAX]
                     if is_terminal_error(d):
                         terminal += 1
                         err_msg = f"terminal: {err_msg}"
@@ -113,19 +144,34 @@ def collect_answer_errors(data_root, model, categories):
 
 
 def collect_eval_errors(data_root, model, categories):
-    """Count eval failures from judgment files."""
+    """Count eval failures from judgment files.
+
+    Judgment files accumulate records across reruns, so a question can have
+    several entries for the same model. Only the latest record (by tstamp)
+    per question reflects reality — a stale eval_timeout that was later
+    re-judged cleanly must not count as an error.
+    """
     results = {}
     for cat in categories:
         pattern = os.path.join(data_root, cat, "*", "model_judgment", "ground_truth_judgment.jsonl")
         for f in sorted(glob.glob(pattern)):
             task = f.split(os.sep)[-3]
             key = f"{cat}/{task}"
-            eval_errors = 0
-            eval_details = {}
+            active = load_active_questions(os.path.dirname(os.path.dirname(f)))
+            latest = {}
             for line in open(f):
                 d = json.loads(line)
                 if d.get("model") != model:
                     continue
+                qid = d.get("question_id")
+                if active is not None and qid not in active:
+                    continue
+                prev = latest.get(qid)
+                if prev is None or d.get("tstamp", 0) >= prev.get("tstamp", 0):
+                    latest[qid] = d
+            eval_errors = 0
+            eval_details = {}
+            for d in latest.values():
                 status = d.get("eval_status", "")
                 if status in EVAL_FAILURE_STATUSES:
                     eval_errors += 1

--- a/livebench/scripts/validate_eval.py
+++ b/livebench/scripts/validate_eval.py
@@ -6,10 +6,18 @@ Reports answer-generation errors, eval errors, and total error rates
 per task, category, and overall. Returns exit code 1 if any category
 exceeds the error threshold.
 
+Only errors a retry can plausibly fix count toward the threshold:
+transient API failures (rate limits, timeouts, dead sockets) and eval
+infrastructure failures (docker errors, eval timeouts, instances that
+never got evaluated). Terminal model failures — token exhaustion
+(finish_reason=length), context-length overflows, content-policy
+refusals — are genuine 0-scores: they are reported in their own column
+but do not trigger retries.
+
 Usage:
     python scripts/validate_eval.py --model minimax-m3
     python scripts/validate_eval.py --model minimax-m3 --threshold 5
-    python scripts/validate_eval.py --model minimax-m3 --category agentic_coding
+    python scripts/validate_eval.py --model minimax-m3 --category agentic_coding_v2
 """
 
 import argparse
@@ -20,22 +28,60 @@ import sys
 
 CATEGORIES = [
     "coding", "data_analysis", "instruction_following",
-    "language", "math", "reasoning", "agentic_coding",
+    "language", "math", "reasoning", "agentic_coding", "agentic_coding_v2",
 ]
 
 ANSWER_ERROR = "$ERROR$"
 
-# Infrastructure failures only — things that prevent reliable scoring.
-# api_error excluded: it's the judgment echo of $ERROR$ in the answer file.
-# patch_error excluded: model produced a malformed patch — that's a wrong answer, not infra.
+# Infrastructure failures only — things that prevent reliable scoring and
+# that a retry can fix. Statuses match what the code actually emits:
+#   eval_error         docker/harness infrastructure error (question skipped)
+#   eval_timeout       eval container killed at the timeout
+#   eval_flaky         legacy: ground-truth fix breaks other tests
+#   not_submitted      instance missing from the eval report (scored 0!)
+#   run_no_trajectory  inference produced no trajectory
+#   run_error          inference harness error
+# Excluded on purpose:
+#   api_error          judgment echo of $ERROR$ in the answer file (double-count)
+#   patch_error        model produced a malformed patch — wrong answer, not infra
+#   empty_patch        model submitted no usable patch — wrong answer, not infra
+#   token_exhaustion   model ran out of tokens — genuine failure, retry won't help
 EVAL_FAILURE_STATUSES = {
-    "eval_error", "eval_timeout",
-    "eval_flaky", "eval_no_fix", "eval_missing_tests",
+    "eval_error", "eval_timeout", "eval_flaky",
+    "not_submitted", "run_no_trajectory", "run_error",
 }
+
+# $ERROR$ answers whose error text matches any of these are terminal model
+# failures: retrying reproduces them, so they must not gate retry rounds.
+TERMINAL_ERROR_PATTERNS = [
+    "finish_reason=length",
+    "token_exhaustion",
+    "context length",
+    "context_length",
+    "context window",
+    "contextwindowexceeded",
+    "maximum context",
+    "prompt is too long",
+    "exceeds the maximum",
+    "content policy",
+    "content_policy",
+    "content_filter",
+    "content management policy",
+    "invalid prompt",
+    "invalidprompt",
+]
+
+DETAIL_KEY_MAX = 60
+
+
+def is_terminal_error(record):
+    """True if this $ERROR$ answer is a genuine model failure, not infra."""
+    text = f"{record.get('error', '')} {record.get('error_msg', '')}".lower()
+    return any(p in text for p in TERMINAL_ERROR_PATTERNS)
 
 
 def collect_answer_errors(data_root, model, categories):
-    """Count $ERROR$ answers per task."""
+    """Count $ERROR$ answers per task, split transient vs terminal."""
     results = {}
     for cat in categories:
         pattern = os.path.join(data_root, cat, "*", "model_answer", f"{model}.jsonl")
@@ -44,15 +90,25 @@ def collect_answer_errors(data_root, model, categories):
             key = f"{cat}/{task}"
             total = 0
             errors = 0
+            terminal = 0
             answer_details = {}
             for line in open(f):
                 d = json.loads(line)
                 total += 1
                 if d["choices"][0]["turns"][0] == ANSWER_ERROR:
-                    errors += 1
-                    err_msg = d.get("error_msg", d.get("error", "unknown"))
+                    err_msg = str(d.get("error_msg", d.get("error", "unknown")))[:DETAIL_KEY_MAX]
+                    if is_terminal_error(d):
+                        terminal += 1
+                        err_msg = f"terminal: {err_msg}"
+                    else:
+                        errors += 1
                     answer_details[err_msg] = answer_details.get(err_msg, 0) + 1
-            results[key] = {"total": total, "answer_errors": errors, "answer_details": answer_details}
+            results[key] = {
+                "total": total,
+                "answer_errors": errors,
+                "terminal_errors": terminal,
+                "answer_details": answer_details,
+            }
     return results
 
 
@@ -90,6 +146,7 @@ def merge_results(answer_results, eval_results):
         e = eval_results.get(key, {})
         total = a.get("total", 0)
         ans_err = a.get("answer_errors", 0)
+        term_err = a.get("terminal_errors", 0)
         eval_err = e.get("eval_errors", 0)
         all_err = ans_err + eval_err
         rate = (all_err / total * 100) if total > 0 else 0
@@ -101,6 +158,7 @@ def merge_results(answer_results, eval_results):
         merged[key] = {
             "total": total,
             "answer_errors": ans_err,
+            "terminal_errors": term_err,
             "eval_errors": eval_err,
             "all_errors": all_err,
             "rate": rate,
@@ -111,12 +169,14 @@ def merge_results(answer_results, eval_results):
 
 def print_report(merged, threshold):
     """Print the validation report."""
+    fields = ["total", "answer_errors", "terminal_errors", "eval_errors", "all_errors"]
+
     # Task-level
-    print(f"{'Task':<50} {'Total':>6} {'Ans':>5} {'Eval':>5} {'All':>5} {'Rate':>7}  Status")
-    print("-" * 95)
+    print(f"{'Task':<50} {'Total':>6} {'Ans':>5} {'Term':>5} {'Eval':>5} {'Retry':>5} {'Rate':>7}  Status")
+    print("-" * 100)
 
     cat_totals = {}
-    overall = {"total": 0, "answer_errors": 0, "eval_errors": 0, "all_errors": 0}
+    overall = {f: 0 for f in fields}
     needs_retry = False
 
     for key in sorted(merged):
@@ -125,8 +185,9 @@ def print_report(merged, threshold):
         status = "RETRY" if r["rate"] > threshold else "OK"
 
         if cat not in cat_totals:
-            cat_totals[cat] = {"total": 0, "answer_errors": 0, "eval_errors": 0, "all_errors": 0, "details": {}}
-        for field in ["total", "answer_errors", "eval_errors", "all_errors"]:
+            cat_totals[cat] = {f: 0 for f in fields}
+            cat_totals[cat]["details"] = {}
+        for field in fields:
             cat_totals[cat][field] += r[field]
             overall[field] += r[field]
         for k, v in r["details"].items():
@@ -136,13 +197,13 @@ def print_report(merged, threshold):
         if r["details"]:
             detail = " (" + ", ".join(f"{v}x {k}" for k, v in sorted(r["details"].items())) + ")"
 
-        if r["all_errors"] > 0:
-            print(f"  {key:<48} {r['total']:>6} {r['answer_errors']:>5} {r['eval_errors']:>5} {r['all_errors']:>5} {r['rate']:>6.1f}%  {status}{detail}")
+        if r["all_errors"] > 0 or r["terminal_errors"] > 0:
+            print(f"  {key:<48} {r['total']:>6} {r['answer_errors']:>5} {r['terminal_errors']:>5} {r['eval_errors']:>5} {r['all_errors']:>5} {r['rate']:>6.1f}%  {status}{detail}")
 
     # Category-level
     print()
-    print(f"{'Category':<50} {'Total':>6} {'Ans':>5} {'Eval':>5} {'All':>5} {'Rate':>7}  Status")
-    print("-" * 95)
+    print(f"{'Category':<50} {'Total':>6} {'Ans':>5} {'Term':>5} {'Eval':>5} {'Retry':>5} {'Rate':>7}  Status")
+    print("-" * 100)
     for cat in sorted(cat_totals):
         c = cat_totals[cat]
         rate = (c["all_errors"] / c["total"] * 100) if c["total"] > 0 else 0
@@ -152,12 +213,16 @@ def print_report(merged, threshold):
         detail = ""
         if c["details"]:
             detail = " (" + ", ".join(f"{v}x {k}" for k, v in sorted(c["details"].items())) + ")"
-        print(f"  {cat:<48} {c['total']:>6} {c['answer_errors']:>5} {c['eval_errors']:>5} {c['all_errors']:>5} {rate:>6.1f}%  {status}{detail}")
+        print(f"  {cat:<48} {c['total']:>6} {c['answer_errors']:>5} {c['terminal_errors']:>5} {c['eval_errors']:>5} {c['all_errors']:>5} {rate:>6.1f}%  {status}{detail}")
 
     # Overall
     print()
     overall_rate = (overall["all_errors"] / overall["total"] * 100) if overall["total"] > 0 else 0
-    print(f"  {'OVERALL':<48} {overall['total']:>6} {overall['answer_errors']:>5} {overall['eval_errors']:>5} {overall['all_errors']:>5} {overall_rate:>6.1f}%")
+    print(f"  {'OVERALL':<48} {overall['total']:>6} {overall['answer_errors']:>5} {overall['terminal_errors']:>5} {overall['eval_errors']:>5} {overall['all_errors']:>5} {overall_rate:>6.1f}%")
+    if overall["terminal_errors"] > 0:
+        print()
+        print(f"  Note: {overall['terminal_errors']} terminal failures (token exhaustion / context length / content policy)")
+        print("  are genuine 0-scores and do not count toward the retry threshold.")
 
     return needs_retry
 
@@ -184,10 +249,10 @@ def main():
 
     print()
     if needs_retry:
-        print("RESULT: RETRY NEEDED — one or more categories exceed %.1f%% error rate" % args.threshold)
+        print("RESULT: RETRY NEEDED — one or more categories exceed %.1f%% retryable error rate" % args.threshold)
         sys.exit(1)
     else:
-        print("RESULT: ALL OK — all categories below %.1f%% error rate" % args.threshold)
+        print("RESULT: ALL OK — all categories below %.1f%% retryable error rate" % args.threshold)
         sys.exit(0)
 
 


### PR DESCRIPTION
## Summary
- `validate_eval.py` and `progress.py` now include `agentic_coding_v2` in their default category lists — v2 runs were invisible to validation.
- The eval-failure status set now matches what the code actually emits (`not_submitted`, `run_no_trajectory`, `run_error` added; `eval_no_fix`/`eval_missing_tests` were never written and are dropped). `empty_patch`/`patch_error`/`token_exhaustion` stay excluded — those are model failures, not infra.
- $ERROR$ answers are split into **retryable** (rate limits, timeouts, transient API/socket failures) vs **terminal** (finish_reason=length token exhaustion, context-window overflow, content policy). Terminal failures are genuine 0-scores: they get their own `Term` column and no longer trigger retry rounds, so models with high token-exhaustion rates (e.g. max-effort reasoning runs) stop burning pointless retries.

## Testing
- Against committed repo data: `claude-sonnet-5-xhigh-effort` shows 16 `finish_reason=length` failures classified terminal and excluded from the retry rate; transient MidStreamFallback/empty errors still count.
- Against a live `agentic_coding_v2` smoke run on a fresh VM: unresolved/empty_patch judged correctly (no false retry), a BadRequestError answer correctly gated a retry, and a litellm `ContextWindowExceededError` is classified terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)