### PR TITLE
agentic: per-instance time limit (time_limit, default 90 min)

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/agents/default.py
+++ b/livebench/agentic_code_runner/minisweagent/agents/default.py
@@ -3,6 +3,7 @@
 import os
 import re
 import subprocess
+import time
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
 import traceback
@@ -48,6 +49,10 @@ class AgentConfig:
     )
     step_limit: int = 0
     cost_limit: float = 0
+    time_limit: float = 0
+    """Wall-clock budget per instance in seconds (0 = disabled). Exceeding it
+    raises LimitsExceeded, so the current diff is auto-submitted exactly like
+    hitting the step limit."""
 
 
 class NonTerminatingException(Exception):
@@ -162,6 +167,7 @@ class DefaultAgent:
             raise RuntimeError(f"Error checking for existing changes: {out}")
         self.existing_git_diff = out["output"]
         self.extra_template_vars |= {"task": task, **kwargs}
+        self._start_time = time.monotonic()
         self.messages = []
         self._empty_submission_nudges = 0
         self.add_message("system", self.render_template(self.config.system_template))
@@ -238,6 +244,10 @@ class DefaultAgent:
         if 0 < self.config.step_limit <= self.model.n_calls:
             logger.info(f"Autosubmitting after step limit exceeded: {self.model.n_calls} steps")
             raise LimitsExceeded("Step limit exceeded")
+        elapsed = time.monotonic() - getattr(self, "_start_time", time.monotonic())
+        if 0 < self.config.time_limit <= elapsed:
+            logger.info(f"Autosubmitting after time limit exceeded: {elapsed:.0f}s over {self.model.n_calls} steps")
+            raise LimitsExceeded("Time limit exceeded")
         response = self.model.query(self.messages)
         self.add_message("assistant", **response)
         return response

--- a/livebench/agentic_code_runner/minisweagent/config/livebench.yaml
+++ b/livebench/agentic_code_runner/minisweagent/config/livebench.yaml
@@ -219,6 +219,11 @@ agent:
     If you have completed your assignment, please consult the first message about how to
     submit your solution (you will not be able to continue working on this task after that).
   step_limit: 250
+  # Per-instance wall-clock budget. On expiry the current diff is auto-submitted
+  # (same semantics as step_limit): work completed before the cap still scores.
+  # Bounds the straggler tail — without it a single instance can run 3-4h
+  # (250 steps x slow long-context calls x 120s test commands).
+  time_limit: 5400
 
 environment:
   cwd: "/testbed"


### PR DESCRIPTION
## Why
Agentic runs have no per-instance time bound — only the 250-step limit and the 120s per-command timeout, i.e. a theoretical 8h+ per instance. In practice the minimax-m2.7 run finished 64/72 instances in 1h35m, then spent **2 more hours** on 8 stragglers; the single worst instance (tsab-core-14624, 234 steps of long-context calls + repeated vitest runs) stretched the run to +3h38m with 14 idle slots.

## How
`time_limit` (seconds, 0 = disabled) in AgentConfig, checked in `query()` right next to the step-limit check. On expiry it raises the **same `LimitsExceeded`** — so the whole downstream path is identical to hitting the step limit: current git diff auto-submitted, `exit_status: LimitsExceeded`, `run_limits_exceeded` eval status, graded normally, not retried. A solve completed before the cap still scores. The trajectory's final message says "Time limit exceeded" vs "Step limit exceeded" for post-hoc analysis. Clock starts per instance at `run()`, so queue position under parallel execution doesn't matter.

Default set to **5400s (90 min)** in livebench.yaml. Rationale: ~92% of all resolves across committed v2 runs happen within 100 steps; slow reasoning models run ~30–60s/step at large context, so 90 min covers ~100–150 slow steps — while capping the pathological tail (this run would have ended at ~2h instead of 3h56m, affecting at most 2–3 flailing instances whose pre-cap diffs would still have been graded).

## Testing
Stub-model unit test: time-limit expiry returns ("LimitsExceeded", diff) with "Time limit exceeded" recorded; step-limit path unchanged; time_limit=0 disabled.

Note: this changes benchmark conditions vs published runs (which had no time cap) — intended as an applied-to-everyone change going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also in this PR: `total_time_s` in answer records
Both pipelines now record how long each question took, so straggler analysis works from committed data instead of VM forensics:
- **Regular** (`gen_api_answer.get_answer`): wall time around the full call — retries, streaming, backoff included.
- **Agentic**: `save_traj` writes `run_time_s` into the trajectory's `model_stats` using the same per-instance clock that drives `time_limit`; `run_inference` copies it into the answer record as `total_time_s`.

Verified with a stub agent (42.0s recorded for a 42s clock).