### PR TITLE
record total time in answer records (regular + agentic)

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/run/utils/save.py
+++ b/livebench/agentic_code_runner/minisweagent/run/utils/save.py
@@ -1,5 +1,6 @@
 import dataclasses
 import json
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -69,6 +70,9 @@ def save_traj(
         # Empty-response resampling observability (getattr-guarded for model classes that lack it)
         data["info"]["model_stats"]["empty_responses"] = getattr(agent.model, "empty_responses", 0)
         data["info"]["model_stats"]["empty_resamples_recovered"] = getattr(agent.model, "empty_resamples_recovered", 0)
+        start_time = getattr(agent, "_start_time", None)
+        if start_time is not None:
+            data["info"]["model_stats"]["run_time_s"] = round(time.monotonic() - start_time, 1)
         for message in agent.messages:
             if 'extra' in message:
                 del message['extra']

--- a/livebench/agentic_code_runner/minisweagent/run_inference.py
+++ b/livebench/agentic_code_runner/minisweagent/run_inference.py
@@ -276,6 +276,7 @@ def run_agentic_coding_inference(
                 'total_cached_tokens': cached_tok,
                 'total_cache_creation_tokens': cache_creation_tok,
                 'n_model_calls': stats.get('api_calls'),
+                'total_time_s': stats.get('run_time_s'),
                 'model_cost': stats.get('instance_cost'),
                 'cost_usd': cost_usd,
             })

--- a/livebench/gen_api_answer.py
+++ b/livebench/gen_api_answer.py
@@ -61,6 +61,7 @@ def get_answer(
         answer_file: The path to the file in which to write answers
         api_dict: A dictionary specifying the base API URL and key for model requests
     """
+    t_start = time.time()
 
     assert (
         force_temperature is not None and "required_temperature" in question.keys()
@@ -143,6 +144,7 @@ def get_answer(
         "model_id": model_display_name_override if model_display_name_override else model_config.display_name.lower(),
         "choices": choices,
         "tstamp": time.time(),
+        "total_time_s": round(time.time() - t_start, 2),
         "total_output_tokens": total_num_tokens,
         "total_input_tokens": total_input_tokens,
         "total_cached_tokens": total_cached_tokens,


### PR DESCRIPTION
Follow-up to #465 — this commit was pushed to that branch after it was merged, so it needs its own PR.

Both pipelines now record how long each question took, so straggler analysis works from committed data instead of VM forensics:
- **Regular** (`gen_api_answer.get_answer`): wall time around the full call — retries, streaming, backoff included — written as `total_time_s` next to the token counts.
- **Agentic**: `save_traj` writes `run_time_s` into the trajectory's `model_stats` using the same per-instance clock that drives `time_limit` (recorded time and budget can never disagree); `run_inference` copies it into the answer record as `total_time_s` alongside `n_model_calls` and `cost_usd`.

Verified with a stub agent (42s clock → `run_time_s: 42.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)