### PR TITLE
ifbench: fix sub-bullets and no_consecutive checkers

### DIFF
--- a/livebench/if_runner/ifbench/instructions.py
+++ b/livebench/if_runner/ifbench/instructions.py
@@ -1276,13 +1276,19 @@ class NoConsecutiveFirstLetterChecker(Instruction):
 		return []
 
 	def check_following(self, value):
-		"""Checks if no two consecutive words in the response share the same first letter."""
-		words = value.lower().translate(str.maketrans('', '', string.punctuation)).split()
-		while '' in words:
-			words.remove('')
-		for i in range(len(words) - 1):
-			if words[i][0] == words[i + 1][0]:
-				return False
+		"""Checks if no two consecutive words in the response share the same first letter.
+
+		Words are compared per line: the last word of a heading/line and the
+		first word of the next line are not consecutive in any reading order,
+		so a newline resets the comparison.
+		"""
+		for line in value.split('\n'):
+			words = line.lower().translate(str.maketrans('', '', string.punctuation)).split()
+			while '' in words:
+				words.remove('')
+			for i in range(len(words) - 1):
+				if words[i][0] == words[i + 1][0]:
+					return False
 		return True
 
 
@@ -1429,11 +1435,21 @@ class SubBulletPointsChecker(Instruction):
 		return []
 
 	def check_following(self, value):
-		"""Checks that there is at least one * that starts a line and each * that starts a line
-		is followed by at least one line starting with -."""
-		bullets = value.split('*')
-		for bullet in bullets[1:]:
-			if "-" not in bullet:
+		"""Checks that there is at least one * bullet line and that each * bullet
+		line is followed by at least one - sub-bullet line before the next bullet.
+
+		Parses lines rather than splitting on '*', which broke on markdown bold
+		(**text** produced an empty fragment that could never contain '-') and
+		accepted any stray hyphen (e.g. 'early-morning') as a sub-bullet.
+		"""
+		lines = value.split('\n')
+		bullet_idx = [i for i, line in enumerate(lines)
+		              if line.lstrip().startswith('* ') or line.strip() == '*']
+		if not bullet_idx:
+			return False
+		for pos, i in enumerate(bullet_idx):
+			nxt = bullet_idx[pos + 1] if pos + 1 < len(bullet_idx) else len(lines)
+			if not any(l.lstrip().startswith('- ') for l in lines[i + 1:nxt]):
 				return False
 		return True
 


### PR DESCRIPTION
Two instruction_following checkers mis-score in ways that punish specific (legitimate) answer styles:

**`SubBulletPointsChecker`** — `value.split('*')` splits on every asterisk, including markdown `**bold**`. The empty fragment between the two asterisks can never contain `-`, so **any answer using bold auto-fails** regardless of its actual bullet structure. It also passes in the wrong direction: any stray hyphen inside a bullet (`early-morning`) counts as a sub-bullet. Fixed with line-based parsing: at least one `* ` bullet line, each followed by at least one `- ` sub-bullet line before the next bullet.

**`NoConsecutiveFirstLetterChecker`** — tokenizes the entire text as one whitespace-split stream, so the last word of a heading and the first word of the following paragraph count as "consecutive" (`again` | `A`, `tax` | `Tax`). Fixed by applying the identical tokenization per line.

## Field impact — full 200-question re-judge of 14 models (old vs new)

| model | old IF | new IF | delta |
|---|---|---|---|
| claude-halva-eap-xhigh-effort | 61.0 | 63.2 | **+2.2** |
| claude-halva-eap-max-effort | 63.5 | 64.5 | **+1.0** |
| fable-5-max / fable-5-xhigh / deepseek-v4-pro / gpt-5.5-high / grok-4.5 / muse-1.1-xhigh / kimi-k2.7 | — | — | +0.3 |
| gemini-3.1-pro-high | 79.7 | 79.9 | +0.2 |
| opus-4.8-high / gpt-5.4-xhigh | — | — | +0.1 |
| claude-opus-4-8-xhigh-effort | 73.6 | 73.6 | 0.0 |
| claude-sonnet-5-xhigh-effort | 66.1 | 66.1 | 0.0 |

The deltas net both directions (bug removals AND false-pass removals). Rank order is unchanged; the fix mainly stops penalizing bold bullet headers and heading→body word transitions.

**Note for maintainers:** committed judgments were produced with whatever checker version was current at judge time (replaying current main over older runs already shifts them +1–3). After merging, a field-wide IF re-judge (`--skip-inference`) would put every model on the same checker vintage.

Tested: 7 directional unit cases (bold-compliant now passes, hyphen-false-pass now fails, plain structures unchanged; cross-line pair passes, same-line violation still fails) + the 14-model re-judge above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)