### PR TITLE
spend_report: per-category avg output tokens and cost per question

### DIFF
--- a/livebench/scripts/cost_utils.py
+++ b/livebench/scripts/cost_utils.py
@@ -1,0 +1,89 @@
+"""Shared cost/token accounting for eval-data scripts.
+
+Single source of truth for the methodology used by spend_report.py here and
+generate_model_rows.py in livebench-private / new-livebench (which vendors the
+same logic to stay standalone). If you change the rules here, mirror them there.
+
+Rules:
+  - cost = uncached_input*input + cache_read*cached_input + output*output, plus
+    cache_creation*cache_creation price for Anthropic models — except on runaway
+    answers at the RUNAWAY_CALLS step cap, whose cache-writes are harness
+    artifacts (the thrashing agent re-wrote the context every call).
+  - total_input_tokens follows two conventions, auto-detected per answer:
+    Anthropic-native reports it EXCLUSIVE of cache reads (cache_read can exceed
+    input); OpenAI/xAI (and some Anthropic runs) report it INCLUSIVE.
+  - $ERROR$ / -1 token sentinels clamp to 0 and are excluded from token averages.
+  - The provider-reported cost_usd is NOT used when config pricing exists: it is
+    inconsistent across providers (undiscounted cache reads, $0 records).
+"""
+import json
+import os
+
+RUNAWAY_CALLS = 250  # agent step cap; see cache-write note above
+
+
+def load_price(model: str):
+    """(input, cached_input, output, cache_creation) USD/1M from the config, or None.
+    Missing cached / cache_creation default to the standard 0.1x / 1.25x of input."""
+    try:
+        from livebench.model import get_model_config
+        cpm = getattr(get_model_config(model), 'cost_per_million', None)
+    except Exception:
+        cpm = None
+    if not cpm:
+        return None
+    in_p = float(cpm.get('input', 0))
+    return (in_p, float(cpm.get('cached_input', in_p * 0.1)),
+            float(cpm.get('output', 0)), float(cpm.get('cache_creation', in_p * 1.25)))
+
+
+def is_anthropic(model: str) -> bool:
+    try:
+        from livebench.model import get_model_config
+        an = getattr(get_model_config(model), 'api_name', {})
+        return 'anthropic' in (an if isinstance(an, dict) else {})
+    except Exception:
+        return model.startswith('claude')
+
+
+def answer_cost(a: dict, in_price, cached_price, out_price, cache_write_price, charge_cache_write) -> float:
+    """Per-answer cost from token counts x config pricing (uniform across providers)."""
+    ti = max(0, a.get('total_input_tokens', 0) or 0)   # clamp $ERROR$/-1 sentinels to 0
+    to = max(0, a.get('total_output_tokens', 0) or 0)
+    cr = max(0, a.get('total_cached_tokens', 0) or 0)
+    cc = max(0, a.get('total_cache_creation_tokens', 0) or 0)
+    ncalls = a.get('n_model_calls') or 0
+    # EXCLUSIVE convention (cr > ti): input is uncached only. INCLUSIVE: input
+    # already contains cache_read (+ cache_creation), so subtract both.
+    uncached = ti if cr > ti else max(0, ti - cr - cc)
+    cost = (uncached * in_price + cr * cached_price + to * out_price) / 1e6
+    if charge_cache_write and cc and ncalls < RUNAWAY_CALLS:
+        cost += cc * cache_write_price / 1e6
+    return cost
+
+
+def active_qids(task_dir: str) -> set:
+    """Question ids that are currently live for a task (empty livebench_removal_date)."""
+    qf = os.path.join(task_dir, 'question.jsonl')
+    ids = set()
+    if os.path.exists(qf):
+        for line in open(qf):
+            if line.strip():
+                q = json.loads(line)
+                if q.get('livebench_removal_date', '') == '':
+                    ids.add(q['question_id'])
+    return ids
+
+
+def latest_per_question(records, keep: set | None = None) -> dict:
+    """One record per question_id — the latest by tstamp. Answer files accumulate
+    re-runs; counting every record over-counts spend. Optionally restrict to `keep`."""
+    latest = {}
+    for r in records:
+        qid = r.get('question_id')
+        if keep is not None and qid not in keep:
+            continue
+        cur = latest.get(qid)
+        if cur is None or (r.get('tstamp') or 0) >= (cur.get('tstamp') or 0):
+            latest[qid] = r
+    return latest

--- a/livebench/scripts/spend_report.py
+++ b/livebench/scripts/spend_report.py
@@ -1,5 +1,12 @@
 """Total API spend per task and per run from model_answer/<model>.jsonl files.
 
+Cost is computed from token counts x config pricing (same methodology as
+scripts/generate_model_rows.py — the provider-reported cost_usd is
+inconsistent across providers and is only used when the config has no
+pricing): uncached_in*input + cache_read*cached_input + output*output,
+plus cache_creation*cache_creation price for models that report cache
+writes (Anthropic).
+
 Usage:
     python scripts/spend_report.py --model minimax-m2.7
     python scripts/spend_report.py --model minimax-m2.7 --bench-name live_bench/math
@@ -15,7 +22,8 @@ from livebench.model import get_model_config
 
 
 def load_price(model: str):
-    """Return (input, cached_input, output) USD per 1M tokens, or None."""
+    """Return (input, cached_input, output, cache_creation) USD per 1M tokens, or None.
+    Missing cached / cache_creation default to the standard 0.1x / 1.25x of input."""
     try:
         cfg = get_model_config(model)
         cpm = getattr(cfg, 'cost_per_million', None)
@@ -24,7 +32,8 @@ def load_price(model: str):
     if not cpm:
         return None
     in_p = float(cpm.get('input', 0))
-    return in_p, float(cpm.get('cached_input', in_p)), float(cpm.get('output', 0))
+    return (in_p, float(cpm.get('cached_input', in_p * 0.1)),
+            float(cpm.get('output', 0)), float(cpm.get('cache_creation', in_p * 1.25)))
 
 
 def main():
@@ -37,7 +46,7 @@ def main():
     args = parser.parse_args()
 
     price = load_price(args.model)
-    in_price, cached_price, out_price = price if price else (None, None, None)
+    in_price, cached_price, out_price, cc_price = price if price else (None, None, None, None)
 
     model_file = f'{args.model.lower()}.jsonl'
     pattern = str(LIVE_BENCH_ROOT_PATH / 'data' / args.bench_name / '**' / 'model_answer' / model_file)
@@ -59,10 +68,14 @@ def main():
 
     grand = {'cost': 0.0, 'in_tok': 0, 'out_tok': 0, 'n': 0, 'partial': 0}
     rows = []
+    cats = {}
     for af in answer_files:
         task = af.split('/data/')[-1].rsplit('/model_answer/', 1)[0]
+        # task path is live_bench/<category>/<task>
+        category = task.split('/')[1] if '/' in task else task
         keep = active_ids(af) if args.active_only else None
         in_tok = out_tok = n = partial = 0
+        valid_n = valid_out = 0
         cost = 0.0
         for line in open(af):
             if not line.strip():
@@ -73,18 +86,27 @@ def main():
             n += 1
             it = r.get('total_input_tokens') or 0
             ct = r.get('total_cached_tokens') or 0
+            cc = r.get('total_cache_creation_tokens') or 0
             ot = r.get('total_output_tokens') or 0
             ot = ot if ot > 0 else 0
             in_tok += it
             out_tok += ot
-            c = r.get('cost_usd')
-            if c is None and price is not None:
+            # cost from tokens x config price (generate_model_rows methodology);
+            # provider cost_usd only when the config has no pricing
+            if price is not None:
                 cached = min(ct, it)
                 uncached = max(it - cached, 0)
-                c = (uncached / 1_000_000) * in_price + (cached / 1_000_000) * cached_price + (ot / 1_000_000) * out_price
-                if not it:
+                c = ((uncached / 1_000_000) * in_price + (cached / 1_000_000) * cached_price
+                     + (ot / 1_000_000) * out_price + (cc / 1_000_000) * cc_price)
+                if not it and not ot:
                     partial += 1
-            cost += (c or 0.0)
+            else:
+                c = r.get('cost_usd') or 0.0
+            cost += c
+            # averages basis: answers with real token data (excludes $ERROR$/empty)
+            if ot > 0:
+                valid_n += 1
+                valid_out += ot
         if n == 0:
             continue
         rows.append((task, n, in_tok, out_tok, cost, partial))
@@ -93,10 +115,15 @@ def main():
         grand['out_tok'] += out_tok
         grand['n'] += n
         grand['partial'] += partial
+        c = cats.setdefault(category, {'n': 0, 'valid_n': 0, 'valid_out': 0, 'cost': 0.0})
+        c['n'] += n
+        c['valid_n'] += valid_n
+        c['valid_out'] += valid_out
+        c['cost'] += cost
 
     rows.sort(key=lambda x: -x[4])
     print(f"\nSpend report for {args.model}"
-          + (f"  (price: ${in_price}/1M in, ${out_price}/1M out)" if price else "  (no price in config)"))
+          + (f"  (price: ${in_price}/1M in, ${out_price}/1M out)" if price else "  (no price in config; using provider cost_usd)"))
     print(f"{'task':<42}{'n':>5}{'in_tok':>12}{'out_tok':>12}{'cost_usd':>12}")
     print('-' * 83)
     for task, n, it, ot, cost, partial in rows:
@@ -104,11 +131,21 @@ def main():
         print(f"{task:<42}{n:>5}{it:>12,}{ot:>12,}{cost:>12.4f}{flag}")
     print('-' * 83)
     print(f"{'TOTAL':<42}{grand['n']:>5}{grand['in_tok']:>12,}{grand['out_tok']:>12,}{grand['cost']:>12.4f}")
+
+    print("\nPer-category averages (over answers with token data; cost = tokens x config price):")
+    print(f"{'category':<26}{'n':>5}{'avg_out_tok/q':>15}{'avg_cost/q':>12}{'total_cost':>12}")
+    print('-' * 70)
+    for category in sorted(cats):
+        c = cats[category]
+        avg_out = c['valid_out'] / c['valid_n'] if c['valid_n'] else 0
+        avg_cost = c['cost'] / c['n'] if c['n'] else 0
+        print(f"{category:<26}{c['n']:>5}{avg_out:>15,.0f}{avg_cost:>12.4f}{c['cost']:>12.4f}")
+
     if grand['partial']:
-        print(f"\n* {grand['partial']} answers had no input-token data (predate cost tracking) -> "
-              f"cost is OUTPUT-ONLY for those; total is a lower bound.")
+        print(f"\n* {grand['partial']} answers had no token data (predate cost tracking or $ERROR$) -> "
+              f"their cost is counted as 0; total is a lower bound.")
     if price is None:
-        print("\nNo cost_per_million in the model config; add it to compute spend.")
+        print("\nNo cost_per_million in the model config; add it to compute spend from tokens.")
 
 
 if __name__ == '__main__':

--- a/livebench/scripts/spend_report.py
+++ b/livebench/scripts/spend_report.py
@@ -1,11 +1,12 @@
 """Total API spend per task and per run from model_answer/<model>.jsonl files.
 
-Cost is computed from token counts x config pricing (same methodology as
-scripts/generate_model_rows.py — the provider-reported cost_usd is
-inconsistent across providers and is only used when the config has no
-pricing): uncached_in*input + cache_read*cached_input + output*output,
-plus cache_creation*cache_creation price for models that report cache
-writes (Anthropic).
+Uses the shared methodology in scripts/cost_utils.py (same rules as
+generate_model_rows.py): cost from token counts x config pricing with
+per-answer detection of the two input-token conventions, cache-write
+billing for Anthropic (excluded on runaway step-cap answers), one
+(latest) answer counted per question, and $ERROR$/-1 sentinels excluded
+from token averages. Provider cost_usd is only used when the config has
+no pricing.
 
 Usage:
     python scripts/spend_report.py --model minimax-m2.7
@@ -16,24 +17,12 @@ import argparse
 import glob
 import json
 import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from cost_utils import active_qids, answer_cost, is_anthropic, latest_per_question, load_price
 
 from livebench.common import LIVE_BENCH_ROOT_PATH
-from livebench.model import get_model_config
-
-
-def load_price(model: str):
-    """Return (input, cached_input, output, cache_creation) USD per 1M tokens, or None.
-    Missing cached / cache_creation default to the standard 0.1x / 1.25x of input."""
-    try:
-        cfg = get_model_config(model)
-        cpm = getattr(cfg, 'cost_per_million', None)
-    except Exception:
-        cpm = None
-    if not cpm:
-        return None
-    in_p = float(cpm.get('input', 0))
-    return (in_p, float(cpm.get('cached_input', in_p * 0.1)),
-            float(cpm.get('output', 0)), float(cpm.get('cache_creation', in_p * 1.25)))
 
 
 def main():
@@ -46,7 +35,10 @@ def main():
     args = parser.parse_args()
 
     price = load_price(args.model)
-    in_price, cached_price, out_price, cc_price = price if price else (None, None, None, None)
+    charge_cache_write = is_anthropic(args.model)
+    in_price = out_price = None
+    if price:
+        in_price, cached_price, out_price, cc_price = price
 
     model_file = f'{args.model.lower()}.jsonl'
     pattern = str(LIVE_BENCH_ROOT_PATH / 'data' / args.bench_name / '**' / 'model_answer' / model_file)
@@ -55,66 +47,42 @@ def main():
         print(f'No answer files for {args.model} under {args.bench_name}')
         return
 
-    def active_ids(answer_file):
-        qf = os.path.join(os.path.dirname(os.path.dirname(answer_file)), 'question.jsonl')
-        ids = set()
-        if os.path.exists(qf):
-            for line in open(qf):
-                if line.strip():
-                    q = json.loads(line)
-                    if q.get('livebench_removal_date', '') == '':
-                        ids.add(q['question_id'])
-        return ids
-
-    grand = {'cost': 0.0, 'in_tok': 0, 'out_tok': 0, 'n': 0, 'partial': 0}
+    grand = {'cost': 0.0, 'in_tok': 0, 'out_tok': 0, 'n': 0, 'no_tok': 0}
     rows = []
     cats = {}
     for af in answer_files:
         task = af.split('/data/')[-1].rsplit('/model_answer/', 1)[0]
         # task path is live_bench/<category>/<task>
         category = task.split('/')[1] if '/' in task else task
-        keep = active_ids(af) if args.active_only else None
-        in_tok = out_tok = n = partial = 0
+        keep = active_qids(os.path.dirname(os.path.dirname(af))) if args.active_only else None
+        records = (json.loads(l) for l in open(af) if l.strip())
+        answers = latest_per_question(records, keep)
+        in_tok = out_tok = no_tok = 0
         valid_n = valid_out = 0
         cost = 0.0
-        for line in open(af):
-            if not line.strip():
-                continue
-            r = json.loads(line)
-            if keep is not None and r.get('question_id') not in keep:
-                continue
-            n += 1
-            it = r.get('total_input_tokens') or 0
-            ct = r.get('total_cached_tokens') or 0
-            cc = r.get('total_cache_creation_tokens') or 0
-            ot = r.get('total_output_tokens') or 0
-            ot = ot if ot > 0 else 0
+        for a in answers.values():
+            it = max(0, a.get('total_input_tokens') or 0)
+            ot = max(0, a.get('total_output_tokens') or 0)
             in_tok += it
             out_tok += ot
-            # cost from tokens x config price (generate_model_rows methodology);
-            # provider cost_usd only when the config has no pricing
             if price is not None:
-                cached = min(ct, it)
-                uncached = max(it - cached, 0)
-                c = ((uncached / 1_000_000) * in_price + (cached / 1_000_000) * cached_price
-                     + (ot / 1_000_000) * out_price + (cc / 1_000_000) * cc_price)
-                if not it and not ot:
-                    partial += 1
+                cost += answer_cost(a, in_price, cached_price, out_price, cc_price, charge_cache_write)
             else:
-                c = r.get('cost_usd') or 0.0
-            cost += c
-            # averages basis: answers with real token data (excludes $ERROR$/empty)
+                cost += a.get('cost_usd') or 0.0
             if ot > 0:
                 valid_n += 1
                 valid_out += ot
+            else:
+                no_tok += 1
+        n = len(answers)
         if n == 0:
             continue
-        rows.append((task, n, in_tok, out_tok, cost, partial))
+        rows.append((task, n, in_tok, out_tok, cost, no_tok))
         grand['cost'] += cost
         grand['in_tok'] += in_tok
         grand['out_tok'] += out_tok
         grand['n'] += n
-        grand['partial'] += partial
+        grand['no_tok'] += no_tok
         c = cats.setdefault(category, {'n': 0, 'valid_n': 0, 'valid_out': 0, 'cost': 0.0})
         c['n'] += n
         c['valid_n'] += valid_n
@@ -126,8 +94,8 @@ def main():
           + (f"  (price: ${in_price}/1M in, ${out_price}/1M out)" if price else "  (no price in config; using provider cost_usd)"))
     print(f"{'task':<42}{'n':>5}{'in_tok':>12}{'out_tok':>12}{'cost_usd':>12}")
     print('-' * 83)
-    for task, n, it, ot, cost, partial in rows:
-        flag = ' *' if partial else ''
+    for task, n, it, ot, cost, no_tok in rows:
+        flag = ' *' if no_tok else ''
         print(f"{task:<42}{n:>5}{it:>12,}{ot:>12,}{cost:>12.4f}{flag}")
     print('-' * 83)
     print(f"{'TOTAL':<42}{grand['n']:>5}{grand['in_tok']:>12,}{grand['out_tok']:>12,}{grand['cost']:>12.4f}")
@@ -141,9 +109,9 @@ def main():
         avg_cost = c['cost'] / c['n'] if c['n'] else 0
         print(f"{category:<26}{c['n']:>5}{avg_out:>15,.0f}{avg_cost:>12.4f}{c['cost']:>12.4f}")
 
-    if grand['partial']:
-        print(f"\n* {grand['partial']} answers had no token data (predate cost tracking or $ERROR$) -> "
-              f"their cost is counted as 0; total is a lower bound.")
+    if grand['no_tok']:
+        print(f"\n* {grand['no_tok']} answers had no token data ($ERROR$ or predate cost tracking) -> "
+              f"cost 0 for those; totals are a lower bound.")
     if price is None:
         print("\nNo cost_per_million in the model config; add it to compute spend from tokens.")
 


### PR DESCRIPTION
Adds a per-category summary block to the spend report (shown in the workflow job summary):

```
Per-category averages (over answers with token data; cost = tokens x config price):
category                      n  avg_out_tok/q  avg_cost/q  total_cost
agentic_coding_v2            72         37,636      0.8761     63.0806
coding                      117          2,220      0.0355      4.1491
...
```

Cost now follows the `generate_model_rows.py` methodology: computed from token counts × config pricing — **including `cache_creation` tokens** (previously ignored, which undercounted Anthropic spend) — with provider `cost_usd` used only as a fallback when the config has no pricing. Token averages are over answers with real token data (excludes $ERROR$/empty ones so they don't deflate the mean).

Verified against committed data: claude-sonnet-5-xhigh-effort (Anthropic pricing + cache writes) and claude-halva-eap-max-effort (no pricing → fallback path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update: shared methodology via `scripts/cost_utils.py`
The accounting rules from `generate_model_rows.py` are now extracted into `scripts/cost_utils.py` and `spend_report.py` is rebuilt on it: per-answer detection of the two `total_input_tokens` conventions (Anthropic-exclusive vs OpenAI-inclusive — the old `min()` formula undercounted Anthropic cache reads ~2×: sonnet-5-xhigh agentic v2 $63 → $134), Anthropic-only cache-write billing excluded on runaway step-cap answers, one (latest) answer per question, sentinel clamping.

**Cross-checked**: per-category spend_report sums now reproduce the generate_model_rows cost-row columns to the cent (claude-sonnet-5-xhigh-effort, all 7 categories).