### PR TITLE
Add kimi-k3 model config

### DIFF
--- a/livebench/model/model_configs/moonshotai.yml
+++ b/livebench/model/model_configs/moonshotai.yml
@@ -90,3 +90,21 @@ api_kwargs:
     temperature: 1.0
     max_tokens: 127000
     stream: true
+---
+display_name: kimi-k3
+cost_per_million:
+  input: 3.00
+  cached_input: 0.30
+  output: 15.00
+api_name:
+  https://api.moonshot.ai/v1: kimi-k3
+api_keys:
+  https://api.moonshot.ai/v1: MOONSHOTAI_API_KEY
+default_provider: https://api.moonshot.ai/v1
+api_kwargs:
+  default:
+    temperature: 1.0
+    max_tokens: 131072
+    stream: true
+    reasoning_effort: max
+preserve_reasoning: true


### PR DESCRIPTION
## What

Adds a `kimi-k3` entry to `moonshotai.yml` — Moonshot's flagship K3 (1M-token context), served at `https://api.moonshot.ai/v1` via the OpenAI-compatible chat API.

```yaml
display_name: kimi-k3
cost_per_million:
  input: 3.00
  cached_input: 0.30
  output: 15.00
api_name:
  https://api.moonshot.ai/v1: kimi-k3
api_keys:
  https://api.moonshot.ai/v1: MOONSHOTAI_API_KEY
default_provider: https://api.moonshot.ai/v1
api_kwargs:
  default:
    temperature: 1.0
    max_tokens: 131072
    stream: true
    reasoning_effort: max
preserve_reasoning: true
```

## Notes

- **Reasoning is always on** for K3; depth is set via `reasoning_effort`, which currently accepts only `max`. LiteLLM forwards it via the `passthrough('reasoning_effort')` path.
- `stream: true` so the request timeout bounds inter-chunk gaps rather than total generation time (K3 at `max` effort emits large outputs).
- **Official pricing** (per 1M tokens): input `$3.00` (cache miss), cached_input `$0.30` (cache hit), output `$15.00`.

## Verification

- Config loads via `get_model_config('kimi-k3')`; cost fields parse as `{input: 3.0, cached_input: 0.3, output: 15.0}`.
- Smoke-tested end-to-end on both paths:
  - **normal** (`math/AMPS_Hard`): API OK, tokens `in=131 / out=709`, grading OK.
  - **agentic** (`agentic_coding_v2/python`, marshmallow-2909 → resolved): 16 API calls, `in=107,949 / out=6,025`, cached `94,720` (**87.7% input cache-hit**, 0 cache-creation).

