### PR TITLE
config(inkling): raise max_tokens 32768→128000 (rescue xhigh token_exhaustion)

### DIFF
--- a/livebench/model/model_configs/tinker.yml
+++ b/livebench/model/model_configs/tinker.yml
@@ -7,7 +7,7 @@
 # Inkling is a native tool-caller: on agent-style prompts it emits tool calls
 # instead of text bash blocks (content comes back empty). The agentic overlay
 # declares a bash tool and the agentic model wrapper synthesizes the ```bash
-# block from the tool call. Context is 64K, so agentic caps max_tokens at 8k
+# block from the tool call. Context is 256K; agentic caps max_tokens at 8k
 # to leave input headroom for long trajectories.
 ---
 display_name: inkling-high
@@ -18,7 +18,7 @@ api_keys:
 api_kwargs:
   default:
     temperature: 1
-    max_tokens: 32768
+    max_tokens: 128000
     reasoning_effort: high
     stream: true
   agentic:
@@ -48,7 +48,7 @@ api_keys:
 api_kwargs:
   default:
     temperature: 1
-    max_tokens: 32768
+    max_tokens: 128000
     reasoning_effort: xhigh
     stream: true
   agentic:


### PR DESCRIPTION
## What

Raise `max_tokens` from `32768` → `128000` for both `inkling-high` and `inkling-xhigh` (regular `default` kwargs). Agentic overlays stay at `8192`. Also corrects the context note in the header comment (256K, not 64K).

## Why

At `reasoning_effort: xhigh`, Inkling emits very long chain-of-thought. With `separate_reasoning: true` the CoT is stripped from `content`, so when a question's reasoning exceeds the output budget the model hits `finish_reason=length` **before emitting any answer** → empty completions (`eval_status: token_exhaustion`). At 32768 this affected ~22% of the LiveBench regular set (264/1198), concentrated in data_analysis, math, and reasoning.

The Tinker endpoint for Inkling is the **256K-context** deployment (verified: a 12,092-token-input question generated a full 64,000 output tokens = ~76K total context), so raising the output cap is genuinely usable, not clipped by the context window.

## Impact (measured)

Rerunning the exhausters at successively higher caps:

| | 32768 | 64000 | **128000** |
|---|---|---|---|
| token_exhaustion empties | 264 | 97 | **4** |
| data_analysis | 46.3 | 54.3 | **72.8** |
| math | 62.4 | 81.7 | **88.4** |
| reasoning | 51.1 | 76.6 | **78.4** |
| **overall** | 55.9 | 71.0 | **75.7** |

93 of the 97 that still exhausted at 64K were rescued at 128K (30+ genuinely crossed 64K output, median ~87K, max ~120K). Only 4 questions reason past 128K — those are genuine model failures / real 0-scores.

## Cost note

Questions that fully exhaust now generate up to 128K output tokens (~28 min each). This is intended — the alternative is a silent 0-score. `reasoning_effort: high` (less CoT) is a separate lever if a cheaper profile is wanted.
