### PR TITLE
Harden agent harness against runaway-command output floods (batch livelock fix)

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/agents/default.py
+++ b/livebench/agentic_code_runner/minisweagent/agents/default.py
@@ -84,6 +84,17 @@ class ExecutionTimeoutError(NonTerminatingException):
     """Raised when the action execution timed out."""
 
 
+_TIMEOUT_OUTPUT_CAP = 10_000
+
+
+def _truncate_middle(text: str, cap: int = _TIMEOUT_OUTPUT_CAP) -> str:
+    """Bound a runaway command's captured output, keeping head and tail."""
+    if len(text) <= cap:
+        return text
+    half = cap // 2
+    return f"{text[:half]}\n... [{len(text) - cap:,} chars truncated] ...\n{text[-half:]}"
+
+
 class TerminatingException(Exception):
     """Raised for conditions that terminate the agent."""
 
@@ -176,7 +187,10 @@ class DefaultAgent:
             try:
                 self.step()
             except NonTerminatingException as e:
-                logger.warning(f"Non-terminating exception: {e}")
+                # Cap the logged copy: rendering a multi-MB message through
+                # rich's highlighter livelocks the whole batch (it holds the
+                # global logging lock). The full text still reaches the model.
+                logger.warning(f"Non-terminating exception: {str(e)[:2000]}")
                 self.add_message("user", str(e))
             except Submitted as e:
                 # has_finished() already captured the submission diff
@@ -290,6 +304,11 @@ class DefaultAgent:
             output = self.env.execute(action["action"])
         except subprocess.TimeoutExpired as e:
             output = e.output.decode("utf-8", errors="replace") if e.output else ""
+            # A command that floods stdout until the timeout (e.g. an agent
+            # reproducing an infinite-loop bug) can produce hundreds of MB
+            # here; unbounded, it ends up in the exception message and from
+            # there in both the log record and the model context.
+            output = _truncate_middle(output)
             raise ExecutionTimeoutError(
                 self.render_template(self.config.timeout_template, action=action, output=output)
             )

--- a/livebench/agentic_code_runner/minisweagent/agents/default.py
+++ b/livebench/agentic_code_runner/minisweagent/agents/default.py
@@ -187,9 +187,7 @@ class DefaultAgent:
             try:
                 self.step()
             except NonTerminatingException as e:
-                # Cap the logged copy: rendering a multi-MB message through
-                # rich's highlighter livelocks the whole batch (it holds the
-                # global logging lock). The full text still reaches the model.
+                # Cap the log copy; huge messages livelock rich's highlighter.
                 logger.warning(f"Non-terminating exception: {str(e)[:2000]}")
                 self.add_message("user", str(e))
             except Submitted as e:
@@ -304,10 +302,7 @@ class DefaultAgent:
             output = self.env.execute(action["action"])
         except subprocess.TimeoutExpired as e:
             output = e.output.decode("utf-8", errors="replace") if e.output else ""
-            # A command that floods stdout until the timeout (e.g. an agent
-            # reproducing an infinite-loop bug) can produce hundreds of MB
-            # here; unbounded, it ends up in the exception message and from
-            # there in both the log record and the model context.
+            # A flooding command can emit 100s of MB before the timeout; bound it.
             output = _truncate_middle(output)
             raise ExecutionTimeoutError(
                 self.render_template(self.config.timeout_template, action=action, output=output)

--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -21,9 +21,8 @@ from livebench.agentic_code_runner.minisweagent.utils.log import logger
 
 
 class GeminiContentFilterError(RuntimeError):
-    """Gemini server-side content filter aborted generation (finish_reason OTHER /
-    RECITATION). Deterministic for the prompt: excluded from tenacity retry, and the
-    message contains "content policy" so validate_eval classifies it as terminal."""
+    """Gemini content filter aborted generation (finish_reason OTHER/RECITATION).
+    Deterministic per prompt: not retried; fails the instance fast."""
 
 
 class LengthFinishReasonError(Exception):
@@ -140,11 +139,8 @@ class LitellmModel:
     def _query_completion_generativeai(self, messages: list[dict[str, str]], **kwargs):
         from google import genai
         from google.genai import types
-        # Hard client-side deadline: gemini-3.6-flash can hold a connection
-        # open indefinitely on filter-triggering prompts (observed: first call
-        # hanging 6+ min with no server response). 600s accommodates the
-        # longest legitimate thinking generations; a hang becomes a timeout
-        # exception that tenacity retries and eventually surfaces as $ERROR$.
+        # 600s hard deadline: Gemini can hold a connection open indefinitely
+        # on filter-triggering prompts, pinning the worker.
         client = genai.Client(api_key=os.environ["GEMINI_API_KEY"],
                               http_options=types.HttpOptions(timeout=600_000))
         actual_messages: list[types.ContentOrDict] = []
@@ -181,13 +177,8 @@ class LitellmModel:
 
         actual_model_name = self.config.model_name.split('/')[-1]
 
-        # Empty-text handling mirrors the Anthropic path (kimi-k3 incident): a
-        # short bounded resample, then RETURN empty content rather than raising.
-        # Raising into the outer tenacity retry never returns to the agent, so
-        # no step is counted and the instance burns wall clock invisibly under
-        # a 4..120s backoff designed for rate limits -- these are HTTP-200
-        # empty candidates, not throttling. Returning "" counts a normal step
-        # (the agent's format nudge advances the loop, bounded by step_limit).
+        # Empty text: resample briefly, then return "" so a step is counted
+        # (raising into tenacity's 4..120s backoff hides it from the agent).
         max_empty_resamples = 3
         for _empty_attempt in range(max_empty_resamples + 1):
             response = client.models.generate_content(model=actual_model_name, contents=actual_messages, config=config)
@@ -212,30 +203,17 @@ class LitellmModel:
             self.empty_responses += 1
 
             if finish.endswith('OTHER') or finish.endswith('RECITATION'):
-                # Server-side content filter: OTHER is the legacy API masking a
-                # policy block (the Interactions API returns an explicit 400
-                # "Request blocked for an unspecified policy reason" for the
-                # same prompt); RECITATION is the recitation filter. Both are
-                # deterministic for the prompt -- resampling or tenacity
-                # retries just reproduce them. Fail the instance fast; the
-                # phrase "content policy" makes validate_eval classify it as
-                # terminal so it never gates retry rounds.
-                logger.error(
-                    f"Gemini content-filter abort (finish_reason={finish}, thoughts_tokens={thoughts}); "
-                    "failing instance -- content policy block, not retryable"
-                )
+                # Server-side content filter; deterministic per prompt, so
+                # exit early instead of retrying. ("content policy" in the
+                # message makes validate_eval classify it as terminal.)
+                logger.error(f"Gemini content-filter abort (finish_reason={finish}); failing instance")
                 raise GeminiContentFilterError(
                     f"Gemini content policy block: finish_reason={finish}, generation aborted server-side"
                 )
 
             if finish.endswith('MAX_TOKENS'):
-                # Thought-only response: the whole output budget went to
-                # thinking. Deterministic token exhaustion -- resampling just
-                # reproduces it, so don't.
-                logger.warning(
-                    f"Gemini thought-only response (finish_reason={finish}, "
-                    f"thoughts_tokens={thoughts}); treating as token exhaustion with empty content"
-                )
+                # Whole output budget went to thinking: token exhaustion, don't retry.
+                logger.warning(f"Gemini thought-only response (thoughts_tokens={thoughts}); returning empty content")
                 message = ""
                 break
 

--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -169,11 +169,43 @@ class LitellmModel:
         actual_model_name = self.config.model_name.split('/')[-1]
 
         response = client.models.generate_content(model=actual_model_name, contents=actual_messages, config=config)
-        
-        if response.text is None or response.candidates is None or len(response.candidates) == 0:
-            raise Exception("No response returned from Google")
-        
-        message = response.text
+
+        if response.candidates is None or len(response.candidates) == 0:
+            raise Exception(
+                "No response returned from Google: no candidates "
+                f"(prompt_feedback={getattr(response, 'prompt_feedback', None)})"
+            )
+
+        if response.text is None:
+            # A candidate came back but with no visible text. Two distinct cases,
+            # previously conflated into one blind-retried "No response" exception:
+            cand = response.candidates[0]
+            finish = str(getattr(cand, 'finish_reason', ''))
+            um = response.usage_metadata
+            thoughts = getattr(um, 'thoughts_token_count', None) if um is not None else None
+            if finish.endswith('MAX_TOKENS'):
+                # Thought-only response: the whole output budget went to thinking.
+                # That is token exhaustion, not a transient failure -- the outer
+                # tenacity retry would reproduce it while backing off up to 120s.
+                # Return empty content instead; the agent's format-error nudge
+                # advances the loop, bounded by step_limit.
+                self.empty_responses += 1
+                logger.warning(
+                    f"Gemini thought-only response (finish_reason={finish}, "
+                    f"thoughts_tokens={thoughts}); treating as token exhaustion with empty content"
+                )
+                message = ""
+            else:
+                # Genuinely empty text without MAX_TOKENS: transient Google-side
+                # empty candidate. Retrying works -- but say what actually came
+                # back so the retry log is diagnosable.
+                raise Exception(
+                    f"Empty text response from Google (finish_reason={finish}, "
+                    f"thoughts_tokens={thoughts}, "
+                    f"prompt_feedback={getattr(response, 'prompt_feedback', None)})"
+                )
+        else:
+            message = response.text
 
         result: dict[str, Any] = {
             'response': response,

--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -140,7 +140,13 @@ class LitellmModel:
     def _query_completion_generativeai(self, messages: list[dict[str, str]], **kwargs):
         from google import genai
         from google.genai import types
-        client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+        # Hard client-side deadline: gemini-3.6-flash can hold a connection
+        # open indefinitely on filter-triggering prompts (observed: first call
+        # hanging 6+ min with no server response). 600s accommodates the
+        # longest legitimate thinking generations; a hang becomes a timeout
+        # exception that tenacity retries and eventually surfaces as $ERROR$.
+        client = genai.Client(api_key=os.environ["GEMINI_API_KEY"],
+                              http_options=types.HttpOptions(timeout=600_000))
         actual_messages: list[types.ContentOrDict] = []
         system = None
         for message in messages:

--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -168,44 +168,62 @@ class LitellmModel:
 
         actual_model_name = self.config.model_name.split('/')[-1]
 
-        response = client.models.generate_content(model=actual_model_name, contents=actual_messages, config=config)
+        # Empty-text handling mirrors the Anthropic path (kimi-k3 incident): a
+        # short bounded resample, then RETURN empty content rather than raising.
+        # Raising into the outer tenacity retry never returns to the agent, so
+        # no step is counted and the instance burns wall clock invisibly under
+        # a 4..120s backoff designed for rate limits -- these are HTTP-200
+        # empty candidates, not throttling. Returning "" counts a normal step
+        # (the agent's format nudge advances the loop, bounded by step_limit).
+        max_empty_resamples = 3
+        for _empty_attempt in range(max_empty_resamples + 1):
+            response = client.models.generate_content(model=actual_model_name, contents=actual_messages, config=config)
 
-        if response.candidates is None or len(response.candidates) == 0:
-            raise Exception(
-                "No response returned from Google: no candidates "
-                f"(prompt_feedback={getattr(response, 'prompt_feedback', None)})"
-            )
+            if response.candidates is None or len(response.candidates) == 0:
+                raise Exception(
+                    "No response returned from Google: no candidates "
+                    f"(prompt_feedback={getattr(response, 'prompt_feedback', None)})"
+                )
 
-        if response.text is None:
-            # A candidate came back but with no visible text. Two distinct cases,
-            # previously conflated into one blind-retried "No response" exception:
+            if response.text is not None:
+                message = response.text
+                if _empty_attempt > 0:
+                    self.empty_resamples_recovered += 1
+                    logger.warning(f"Recovered from empty Gemini response after {_empty_attempt} resample(s)")
+                break
+
             cand = response.candidates[0]
             finish = str(getattr(cand, 'finish_reason', ''))
             um = response.usage_metadata
             thoughts = getattr(um, 'thoughts_token_count', None) if um is not None else None
+            self.empty_responses += 1
+
             if finish.endswith('MAX_TOKENS'):
-                # Thought-only response: the whole output budget went to thinking.
-                # That is token exhaustion, not a transient failure -- the outer
-                # tenacity retry would reproduce it while backing off up to 120s.
-                # Return empty content instead; the agent's format-error nudge
-                # advances the loop, bounded by step_limit.
-                self.empty_responses += 1
+                # Thought-only response: the whole output budget went to
+                # thinking. Deterministic token exhaustion -- resampling just
+                # reproduces it, so don't.
                 logger.warning(
                     f"Gemini thought-only response (finish_reason={finish}, "
                     f"thoughts_tokens={thoughts}); treating as token exhaustion with empty content"
                 )
                 message = ""
-            else:
-                # Genuinely empty text without MAX_TOKENS: transient Google-side
-                # empty candidate. Retrying works -- but say what actually came
-                # back so the retry log is diagnosable.
-                raise Exception(
+                break
+
+            if _empty_attempt < max_empty_resamples:
+                backoff = min(2 ** _empty_attempt, 8)
+                logger.warning(
                     f"Empty text response from Google (finish_reason={finish}, "
-                    f"thoughts_tokens={thoughts}, "
-                    f"prompt_feedback={getattr(response, 'prompt_feedback', None)})"
+                    f"thoughts_tokens={thoughts}); resampling "
+                    f"(attempt {_empty_attempt + 1}/{max_empty_resamples}, sleeping {backoff}s)"
                 )
-        else:
-            message = response.text
+                time.sleep(backoff)
+                continue
+
+            logger.warning(
+                f"Empty text response from Google persisted after {max_empty_resamples} "
+                f"resamples (finish_reason={finish}); returning empty content"
+            )
+            message = ""
 
         result: dict[str, Any] = {
             'response': response,

--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -20,6 +20,12 @@ from livebench.agentic_code_runner.minisweagent.models import GLOBAL_MODEL_STATS
 from livebench.agentic_code_runner.minisweagent.utils.log import logger
 
 
+class GeminiContentFilterError(RuntimeError):
+    """Gemini server-side content filter aborted generation (finish_reason OTHER /
+    RECITATION). Deterministic for the prompt: excluded from tenacity retry, and the
+    message contains "content policy" so validate_eval classifies it as terminal."""
+
+
 class LengthFinishReasonError(Exception):
     """Raised when the model returns finish_reason='length' but completion_tokens < max_tokens."""
 
@@ -126,6 +132,7 @@ class LitellmModel:
         retry=retry_if_not_exception_type(
             (
                 KeyboardInterrupt,
+                GeminiContentFilterError,
             )
         ),
         reraise=True,
@@ -197,6 +204,23 @@ class LitellmModel:
             um = response.usage_metadata
             thoughts = getattr(um, 'thoughts_token_count', None) if um is not None else None
             self.empty_responses += 1
+
+            if finish.endswith('OTHER') or finish.endswith('RECITATION'):
+                # Server-side content filter: OTHER is the legacy API masking a
+                # policy block (the Interactions API returns an explicit 400
+                # "Request blocked for an unspecified policy reason" for the
+                # same prompt); RECITATION is the recitation filter. Both are
+                # deterministic for the prompt -- resampling or tenacity
+                # retries just reproduce them. Fail the instance fast; the
+                # phrase "content policy" makes validate_eval classify it as
+                # terminal so it never gates retry rounds.
+                logger.error(
+                    f"Gemini content-filter abort (finish_reason={finish}, thoughts_tokens={thoughts}); "
+                    "failing instance -- content policy block, not retryable"
+                )
+                raise GeminiContentFilterError(
+                    f"Gemini content policy block: finish_reason={finish}, generation aborted server-side"
+                )
 
             if finish.endswith('MAX_TOKENS'):
                 # Thought-only response: the whole output budget went to

--- a/livebench/agentic_code_runner/minisweagent/utils/log.py
+++ b/livebench/agentic_code_runner/minisweagent/utils/log.py
@@ -1,17 +1,23 @@
 import logging
 from pathlib import Path
 
+from rich.highlighter import NullHighlighter
 from rich.logging import RichHandler
 
 
 def _setup_root_logger() -> None:
     logger = logging.getLogger("minisweagent")
     logger.setLevel(logging.DEBUG)
+    # NullHighlighter: the default ReprHighlighter regex-scans every message
+    # while holding the global logging lock — a pathological message (e.g.
+    # millions of URL-ish tokens from a runaway command) livelocks every
+    # worker thread in a batch run. Batch logs don't need syntax colors.
     _handler = RichHandler(
         show_path=False,
         show_time=False,
         show_level=False,
         markup=True,
+        highlighter=NullHighlighter(),
     )
     _formatter = logging.Formatter("%(name)s: %(levelname)s: %(message)s")
     _handler.setFormatter(_formatter)

--- a/livebench/agentic_code_runner/minisweagent/utils/log.py
+++ b/livebench/agentic_code_runner/minisweagent/utils/log.py
@@ -8,10 +8,8 @@ from rich.logging import RichHandler
 def _setup_root_logger() -> None:
     logger = logging.getLogger("minisweagent")
     logger.setLevel(logging.DEBUG)
-    # NullHighlighter: the default ReprHighlighter regex-scans every message
-    # while holding the global logging lock — a pathological message (e.g.
-    # millions of URL-ish tokens from a runaway command) livelocks every
-    # worker thread in a batch run. Batch logs don't need syntax colors.
+    # No highlighter: ReprHighlighter livelocks on pathological messages
+    # while holding the global logging lock, freezing all batch workers.
     _handler = RichHandler(
         show_path=False,
         show_time=False,


### PR DESCRIPTION
Five small guards so agentic batches never wedge or silently spin. Each was hit in production on 2026-07-21 (gemini-3.5-flash-lite / gemini-3.6-flash runs) and verified live.

## The fixes
1. **Truncate runaway command output** (`_truncate_middle`, 10k head+tail) before it enters `ExecutionTimeoutError` — an agent reproduced an infinite-loop bug whose repro flooded ~100MB into the exception, the log, and the model context.
2. **Cap the logged copy** of non-terminating exceptions at 2k chars.
3. **`NullHighlighter` on the batch logger** — rich's `ReprHighlighter` regex-scans messages under the global logging lock; the flood above produced 47.6M spans / 70GB RSS and froze every worker.
4. **Exit early on `finish_reason` OTHER/RECITATION** (`GeminiContentFilterError`, excluded from retry) — these are deterministic server-side content-filter aborts (the Interactions API returns an explicit 400 policy block for the same prompts); retrying reproduces them forever. Other empty responses get 3 quick resamples then return empty so the agent counts a step. `MAX_TOKENS` thought-only responses return empty immediately (token exhaustion).
5. **600s client deadline on the Gemini client** — filter-triggering prompts can hold a connection open indefinitely, pinning the worker.

## Verified
- 100MB flood truncates in <1ms; 1MB URL-dense payload logs in <5s (previously livelocked).
- Live: the gemini-3.6-flash rerun failed 10 filter-blocked instances in seconds each (previously hours of retry), while 18 previously-stuck instances completed with real submissions.
- No scoring change for well-behaved runs; only pathological paths are bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)