### PR TITLE
Route retention-gated Anthropic models (Fable) through the non-ZDR key

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -342,8 +342,10 @@ class LitellmModel:
     def _query_completion_anthropic_direct(self, messages: list[dict[str, str]], **kwargs):
         """Direct Anthropic SDK call to support features not yet in LiteLLM (e.g., thinking.type: auto)"""
         from anthropic import NOT_GIVEN, Anthropic
-        
-        client = Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+
+        from livebench.model.completions import anthropic_api_key
+
+        client = Anthropic(api_key=anthropic_api_key(self.config.model_name))
         
         api_kwargs = self.config.model_kwargs | kwargs
         actual_api_kwargs = {key: (value if value is not None else NOT_GIVEN) for key, value in api_kwargs.items()}

--- a/livebench/model/completions.py
+++ b/livebench/model/completions.py
@@ -25,6 +25,17 @@ API_RETRY_SLEEP_MAX = 60
 API_ERROR_OUTPUT = "$ERROR$"
 TIMEOUT = 1800
 
+# Models gated on 30-day retention (Fable/Mythos tier): the org-default
+# ANTHROPIC_API_KEY is ZDR and gets 400 model_not_available for them, so they
+# use the non-ZDR key instead. Substring-matched against the API model name.
+ANTHROPIC_SKIP_ZDR_MODELS = ('claude-fable-5',)
+
+
+def anthropic_api_key(model: str) -> str | None:
+    if any(name in model for name in ANTHROPIC_SKIP_ZDR_MODELS) and os.environ.get('ANTHROPIC_SKIP_ZDR_API_KEY'):
+        return os.environ['ANTHROPIC_SKIP_ZDR_API_KEY']
+    return os.environ.get('ANTHROPIC_API_KEY')
+
 # model api function takes in Model, list of messages, temperature, max tokens, api kwargs, and an api dict
 # returns tuple of (output, num tokens)
 Conversation = list[dict[str, str]]
@@ -441,7 +452,7 @@ def chat_completion_anthropic(model: str, messages: Conversation, temperature: f
     if api_dict is not None and "api_key" in api_dict:
         api_key = api_dict["api_key"]
     else:
-        api_key = os.environ["ANTHROPIC_API_KEY"]
+        api_key = anthropic_api_key(model)
 
     from anthropic import NOT_GIVEN, Anthropic
     c = Anthropic(api_key=api_key)
@@ -784,6 +795,7 @@ def chat_completion_litellm(
         messages = [{**m, 'role': 'user'} if m.get('role') == 'system' else m for m in messages]
 
     if 'anthropic' in litellm_model:
+        actual_api_kwargs.setdefault('api_key', anthropic_api_key(model))
         if 'betas' in actual_api_kwargs:
             actual_api_kwargs['extra_headers'] = {'anthropic-beta': ','.join(actual_api_kwargs.pop('betas'))}
         if 'extra_body' in actual_api_kwargs:


### PR DESCRIPTION
## Why

`claude-fable-5` requires 30-day data retention; the org-default `ANTHROPIC_API_KEY` is ZDR and returns `400 model_not_available` for it. Previously the skip-zdr key had to be swapped in manually per run.

## What

- `ANTHROPIC_SKIP_ZDR_MODELS` list + `anthropic_api_key(model)` helper in `completions.py`: models on the list use `ANTHROPIC_SKIP_ZDR_API_KEY` when set, everything else (and unset-var fallback) stays on `ANTHROPIC_API_KEY`.
- Applied at all three Anthropic key-resolution points: native SDK path (`chat_completion_anthropic`), litellm path (`chat_completion_litellm`), and the agentic runner's direct-Anthropic client (`litellm_model.py`).
- No model-config changes; the list lives in the harness.

## Verified

- `anthropic_api_key` unit-checked for fable/non-fable names, slashed agentic names (`anthropic/claude-fable-5`), and unset-var fallback; no import cycle from the agentic runner.
- End-to-end: `chat_completion_litellm` (fable xhigh config kwargs, fallbacks reroute → native path) served `claude-fable-5` with `ANTHROPIC_API_KEY` **unset** and only `ANTHROPIC_SKIP_ZDR_API_KEY` present; token/cache accounting intact.

Companion PR: LiveBench/livebench-private#180 (injects the secret in the ondemand workflow; repo secret already set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
