### PR TITLE
Agentic harness: native tool calling for Anthropic models

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/config/livebench_native.yaml
+++ b/livebench/agentic_code_runner/minisweagent/config/livebench_native.yaml
@@ -1,0 +1,162 @@
+# Native tool-calling variant of livebench.yaml (always used for Anthropic models).
+# Identical except the action format: the model calls the `bash` tool instead of
+# formatting a ```bash block for regex parsing.
+agent:
+  system_template: |
+    You are a helpful assistant that can interact multiple times with a computer shell to solve programming tasks.
+
+    Take actions by calling the `bash` tool with exactly ONE command (or commands connected with && or ||).
+    Before each tool call, briefly explain your reasoning for the action.
+
+    Only `bash` tool calls are executed — commands written in plain text are NOT run.
+    Issue one tool call per turn: run a command, see its result, then choose your next command.
+  instance_template: |
+    Please solve the following issue on this repository:
+    <issue_description>
+    {{task}}
+    </issue_description>
+
+    <instructions>
+    # Task Instructions
+
+    ## Overview
+    You're a software engineer interacting continuously with a computer by submitting commands.
+    You'll be helping implement necessary changes to meet requirements in the PR description.
+    Your task is specifically to make changes to non-test files in the current directory in order to fix the issue described in the PR description in a way that is general and consistent with the codebase.
+
+    IMPORTANT: This is an interactive process where you will think and issue ONE command via the `bash` tool, see its result, then think and issue your next command.
+
+    You have up to {{step_limit}} turns available — there is no need to plan multiple commands in one turn. Use one command per turn, see the result, then choose the next one.
+
+    ## Important Boundaries
+    - MODIFY: Regular source code files in the current directory and its subdirectories
+    - DO NOT MODIFY: Tests, configuration files (pyproject.toml, setup.cfg, etc.)
+
+    ## Recommended Workflow
+    1. Analyze the codebase by finding and reading relevant files
+    2. Create a script to reproduce the issue
+    3. Edit the source code to resolve the issue
+    4. Verify your fix works by running your script again
+    5. Test edge cases to ensure your fix is robust
+
+    ## Command Execution Rules
+    You are operating in an environment where
+    1. You call the `bash` tool with a single command
+    2. The system executes that command in a subshell
+    3. You see the result
+    4. You call the `bash` tool with your next command
+
+    **CRITICAL REQUIREMENTS:**
+    - Each turn MUST contain EXACTLY ONE `bash` tool call
+    - The tool call MUST contain EXACTLY ONE command (or a set of commands connected with && or ||)
+    - Do NOT try to run multiple independent commands in one turn
+    - Directory or environment variable changes are not persistent. Every action is executed in a new subshell.
+    - However, you can prefix any command with `MY_ENV_VAR=MY_VALUE cd /path/to/working/dir && ...` or write/load environment variables from files
+
+    If you need to run multiple commands, either:
+    1. Combine them in one command using && or ||, e.g. `command1 && command2 || echo "Error occurred"`
+    2. Wait for the first command to complete, see its output, then issue the next command in your following turn.
+
+    ## Environment Details
+    - You have a full Linux shell environment
+    - Always use non-interactive flags (-y, -f) for commands
+    - Avoid interactive tools like vi, nano, or any that require user input
+    - If a command isn't available, you can install it
+
+    ## Useful Command Examples
+
+    ### Create a new file:
+    ```
+    cat <<'EOF' > newfile.py
+    import numpy as np
+    hello = "world"
+    print(hello)
+    EOF
+    ```
+
+    ### Edit files with sed:
+    ```
+    # Replace all occurrences
+    sed -i 's/old_string/new_string/g' filename.py
+
+    # Replace only first occurrence
+    sed -i 's/old_string/new_string/' filename.py
+
+    # Replace first occurrence on line 1
+    sed -i '1s/old_string/new_string/' filename.py
+
+    # Replace all occurrences in lines 1-10
+    sed -i '1,10s/old_string/new_string/g' filename.py
+    ```
+
+    ### View file content:
+    ```
+    # View specific lines with numbers
+    nl -ba filename.py | sed -n '10,20p'
+    ```
+
+    ## Submission
+    When you've completed your work (reading, editing, testing), and cannot make further progress,
+    call the `bash` tool with exactly the following command:
+
+    ```
+    echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT && git add -A && git diff --cached
+    ```
+
+    This command will submit your work.
+    You cannot continue working (reading, editing, testing) in any way on this task after submitting.
+
+    DO NOT COMMIT YOUR WORK. If you are finished, issue the above command ONLY.
+    </instructions>
+  action_observation_template: |
+    <returncode>{{output.returncode}}</returncode>
+    {% if output.output | length < 10000 -%}
+    <output>
+    {{ output.output -}}
+    </output>
+    {%- else -%}
+    <warning>
+    The output of your last command was too long.
+    Please try a different command that produces less output.
+    If you're looking at a file you can try use head, tail or sed to view a smaller number of lines selectively.
+    If you're using grep or find and it produced too much output, you can use a more selective search pattern.
+    If you really need to see something from the full command's output, you can redirect output to a file and then search in that file.
+    </warning>
+    {%- set elided_chars = output.output | length - 10000 -%}
+    <output_head>
+    {{ output.output[:5000] }}
+    </output_head>
+    <elided_chars>
+    {{ elided_chars }} characters elided
+    </elided_chars>
+    <output_tail>
+    {{ output.output[-5000:] }}
+    </output_tail>
+    {%- endif -%}
+  format_error_template: |
+    Your last response did not include a `bash` tool call, so NO action was executed.
+    Call the `bash` tool with exactly one command to make progress.
+
+    If you have completed your assignment, submit it by calling the `bash` tool with exactly:
+    echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT && git add -A && git diff --cached
+    (you will not be able to continue working on this task after that).
+  step_limit: 250
+  # Per-instance wall-clock budget. On expiry the current diff is auto-submitted
+  # (same semantics as step_limit): work completed before the cap still scores.
+  time_limit: 5400
+
+environment:
+  cwd: "/testbed"
+  timeout: 120
+  env:
+    PAGER: cat
+    MANPAGER: cat
+    LESS: -R
+    PIP_PROGRESS_BAR: 'off'
+    TQDM_DISABLE: '1'
+  environment_class: docker
+  # ANSWER-LEAK / NETWORK ISOLATION: see livebench.yaml for rationale.
+  run_args: ["--rm", "--network", "none"]
+
+model:
+  model_kwargs:

--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -48,6 +48,55 @@ def _cached_tokens(details) -> int:
     return getattr(details, 'cached_tokens', 0) or 0
 
 
+# Native tool calling, always on for Anthropic models: the bash action is a real
+# tool, so generation stops at the tool_use block and a turn can never run past its
+# action into a hallucinated observation. The agent loop stays text-based: the
+# tool_use command is synthesized back into a ```bash block for parse_action, and
+# observation user-turns are wrapped into tool_result blocks at request-prep.
+# Requires the tool-calling prompts in config/livebench_native.yaml (with
+# tool_choice auto, triple-backtick prompts make models ignore the tool).
+_BASH_TOOL = {
+    "name": "bash",
+    "description": (
+        "Run a bash command in the repository environment and see its output. "
+        "Each command runs in a fresh subshell: directory and environment-variable "
+        "changes do not persist between calls (prefix with `cd /path && ...` as needed). "
+        "Always use non-interactive flags; interactive tools are unavailable."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "command": {"type": "string", "description": "The bash command to execute."},
+        },
+        "required": ["command"],
+    },
+}
+
+
+def _wrap_tool_results(messages: list[dict]) -> None:
+    """Wrap each user turn that follows a tool_use assistant turn in a tool_result
+    block (the API requires every tool_use to be answered by one). Mutates in place;
+    callers pass a request-only copy, never the agent's own history."""
+    pending_tool_use_id = None
+    for i, msg in enumerate(messages):
+        if msg.get('role') == 'assistant':
+            pending_tool_use_id = None
+            blocks = msg.get('content')
+            if isinstance(blocks, list):
+                for block in blocks:
+                    if isinstance(block, dict) and block.get('type') == 'tool_use':
+                        pending_tool_use_id = block.get('id')
+                        break
+        elif msg.get('role') == 'user' and pending_tool_use_id is not None:
+            content = msg.get('content')
+            if isinstance(content, str):
+                tool_result: dict[str, Any] = {'type': 'tool_result', 'tool_use_id': pending_tool_use_id}
+                if content.strip():
+                    tool_result['content'] = content
+                messages[i] = {'role': 'user', 'content': [tool_result]}
+            pending_tool_use_id = None
+
+
 def _set_cache_breakpoint(message: dict) -> None:
     """Mark a message's last text block with an ephemeral cache_control breakpoint.
 
@@ -124,6 +173,8 @@ class LitellmModel:
         # object is created per-instance (run_batch.get_model in a thread pool), so the
         # counter is naturally per-instance -- no sharing or reset needed.
         self.consecutive_empty_degrades = 0
+        # turns whose action arrived as a tool_use block (vs regex-parsed text)
+        self.native_tool_use_turns = 0
         if self.config.litellm_model_registry and Path(self.config.litellm_model_registry).is_file():
             litellm.utils.register_model(json.loads(Path(self.config.litellm_model_registry).read_text()))
 
@@ -425,13 +476,21 @@ class LitellmModel:
         max_tokens = actual_api_kwargs.pop('max_tokens', 8192)
         temperature = actual_api_kwargs.pop('temperature', NOT_GIVEN)
         
+        native_tools = self._native_tools_enabled()
+        if native_tools:
+            _wrap_tool_results(actual_messages)
+
         # Build call kwargs - only include supported parameters
         call_kwargs: dict[str, Any] = {
             'model': actual_model_name,
             'messages': actual_messages,
             'max_tokens': max_tokens,
         }
-        
+        if native_tools:
+            call_kwargs['tools'] = [_BASH_TOOL]
+            # at most one tool_use per turn: one-command-per-turn, API-enforced
+            call_kwargs['tool_choice'] = {'type': 'auto', 'disable_parallel_tool_use': True}
+
         if system_content:
             call_kwargs['system'] = [{
                 "type": "text",
@@ -496,10 +555,24 @@ class LitellmModel:
             # Extract non-empty text and build sanitized content for history
             content = ""
             sanitized_content = []
+            tool_command = None
             for block in response.content:
                 block_type = getattr(block, 'type', 'unknown')
 
-                if block_type == "text":
+                if block_type == "tool_use":
+                    if tool_command is not None:
+                        # keeps the 1 tool_use : 1 tool_result pairing valid
+                        logger.warning("Multiple tool_use blocks in one turn; keeping only the first")
+                        continue
+                    tool_input = getattr(block, 'input', {}) or {}
+                    sanitized_content.append({
+                        "type": "tool_use",
+                        "id": getattr(block, 'id', ''),
+                        "name": getattr(block, 'name', ''),
+                        "input": tool_input,
+                    })
+                    tool_command = tool_input.get('command', '') if getattr(block, 'name', '') == 'bash' else ''
+                elif block_type == "text":
                     text = getattr(block, 'text', '')
                     # Only include non-empty text blocks in sanitized content
                     if text.strip():
@@ -523,6 +596,18 @@ class LitellmModel:
                     data = getattr(block, 'data', '')
                     sanitized_content.append({"type": "redacted_thinking", "data": data})
                 # a 'fallback' marker block (present on fallback turns) is intentionally skipped
+
+            if tool_command is not None and tool_command.strip():
+                # synthesize the ```bash block parse_action expects; the raw tool_use
+                # block is what gets replayed to the API
+                self.native_tool_use_turns += 1
+                action_block = f"```bash\n{tool_command}\n```"
+                if content:
+                    # neutralize stray fences so parse_action picks the tool call
+                    content = content.replace("```bash", "```sh")
+                    content = f"{content}\n\n{action_block}"
+                else:
+                    content = action_block
 
             if content:
                 if _empty_attempt > 0:
@@ -590,10 +675,18 @@ class LitellmModel:
 
         return result
 
+    def _native_tools_enabled(self) -> bool:
+        """Native tool calling: bash exposed as a real tool on the Anthropic direct
+        path instead of regex-parsed text. Always on for Anthropic models."""
+        return 'anthropic' in self.config.model_name
+
     def _needs_direct_anthropic_call(self) -> bool:
         """Check if we need to bypass LiteLLM for direct Anthropic SDK call"""
         if 'anthropic' not in self.config.model_name:
             return False
+        if self._native_tools_enabled():
+            # tool_use/tool_result plumbing exists only on the direct path
+            return True
         thinking = self.config.model_kwargs.get('thinking', {})
         # 'auto' and 'adaptive' thinking types require the direct SDK path because
         # LiteLLM does not preserve the `signature` field on thinking blocks when
@@ -862,7 +955,7 @@ class LitellmModel:
                         # the nested dict too: litellm's gemini path reads thought_signatures
                         # from provider_specific_fields only
                         message_copy['extra']['message'] = message_copy['extra']['message'] | provider_fields
-                    actual_messages.append(message_copy['extra']['message'])
+                    actual_messages.append(dict(message_copy['extra']['message']))
                 elif message_copy['extra'].get('outputs') is not None:
                     actual_messages.extend(message_copy['extra']['outputs'])
                 else:

--- a/livebench/agentic_code_runner/minisweagent/run/utils/save.py
+++ b/livebench/agentic_code_runner/minisweagent/run/utils/save.py
@@ -70,6 +70,8 @@ def save_traj(
         # Empty-response resampling observability (getattr-guarded for model classes that lack it)
         data["info"]["model_stats"]["empty_responses"] = getattr(agent.model, "empty_responses", 0)
         data["info"]["model_stats"]["empty_resamples_recovered"] = getattr(agent.model, "empty_resamples_recovered", 0)
+        # actions that arrived as tool_use blocks (== api_calls when every turn tool-called)
+        data["info"]["model_stats"]["native_tool_use_turns"] = getattr(agent.model, "native_tool_use_turns", 0)
         start_time = getattr(agent, "_start_time", None)
         if start_time is not None:
             data["info"]["model_stats"]["run_time_s"] = round(time.monotonic() - start_time, 1)

--- a/livebench/agentic_code_runner/minisweagent/run_inference.py
+++ b/livebench/agentic_code_runner/minisweagent/run_inference.py
@@ -85,7 +85,13 @@ def run_agentic_coding_inference(
     all_traj_folder = LIVE_BENCH_ROOT_PATH / f"agentic_code_runner/data/trajectories" / run_id
     all_traj_folder.mkdir(parents=True, exist_ok=True)
 
-    config_path = LIVE_BENCH_ROOT_PATH / f"agentic_code_runner/minisweagent/config/livebench.yaml"
+    # Anthropic models use native tool calling and need the tool-calling prompts
+    # (with tool_choice auto, triple-backtick prompts make models ignore the tool)
+    native_tools = provider == 'anthropic'
+    config_name = "livebench_native.yaml" if native_tools else "livebench.yaml"
+    if native_tools:
+        print(f"Native tool-calling mode ON: using {config_name}")
+    config_path = LIVE_BENCH_ROOT_PATH / f"agentic_code_runner/minisweagent/config/{config_name}"
     config = yaml.safe_load(open(config_path))
 
     if provider in RESPONSES_API_PROVIDERS:


### PR DESCRIPTION
## What

Anthropic models now take agentic-coding actions via a native `bash` tool instead of formatting a ```` ```bash ```` block that the harness regex-parses out of free text.

- `litellm_model.py`: declare the `bash` tool + `tool_choice {auto, disable_parallel_tool_use}` on the direct Anthropic path; synthesize the returned `tool_use` command back into a ```` ```bash ```` block so the agent loop is unchanged; wrap observation/nudge user turns into `tool_result` blocks at request-prep.
- `livebench_native.yaml`: tool-calling variant of the prompts (identical task instructions; only the action format differs). Required — with `tool_choice: auto`, triple-backtick prompts make models ignore the tool.
- `run_inference.py`: selects the native prompt config for Anthropic providers.
- `save.py`: record `native_tool_use_turns` in `model_stats` so trajectories prove per-instance that actions arrived as tool calls.

## Why

The API stops generation at the `tool_use` block (`stop_reason=tool_use`), so a turn structurally cannot run past its action into a simulated `user<returncode>...` observation — the turn-boundary hallucination that caused fable-5's 17/72 empty-patch collapse. `disable_parallel_tool_use` makes one-command-per-turn API-enforced rather than prompt-requested. This also matches how these models are post-trained (and how Anthropic's own SWE harness works), so text-mode-only failure classes (format errors, fence parsing) disappear.

Non-Anthropic providers are unchanged (text mode, `livebench.yaml`).

## Validation

- Full 72-instance agentic_coding_v2 run (Anthropic EAP model, xhigh, parallel 12): **100% of ~3.4K steps arrived as `tool_use`**, 0 simulated observations, 0 empty responses, 0 format errors, 0 `$ERROR$`, all judgments clean (`resolved`/`unresolved` only).
- Prompt caching unaffected: 97.4% cache-read rate (tools block joins the cached prefix); token/cost tracking unchanged.
- On the 8 active June fable-5 empty-patch questions: 6/8 resolved, 0/8 empty submissions, 0 hallucinated observations in ~450 turns.

## Notes

- Native-mode scores are not directly comparable to text-mode runs; treat as a versioned harness change for Anthropic models.
- The `strip_simulated_observation` request-prep band-aid (uncommitted) is superseded by this and not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)