### PR TITLE
Harden agentic-code testbed against reference-solution leakage

### DIFF
--- a/livebench/agentic_code_runner/eval/harness/image.py
+++ b/livebench/agentic_code_runner/eval/harness/image.py
@@ -170,15 +170,55 @@ git checkout {pr.base.sha} {test_files}
             )
         ]
 
+    def sanitize_run_step(self) -> str:
+        """Dockerfile RUN step that removes every in-image copy of the
+        reference solution before the agent ever sees the container.
+
+        An agent with shell access inside the task container could otherwise
+        recover the reference fix (and the hidden test patch) from:
+          * stray patch files left in /tmp (or /home) by image preparation,
+          * the git object store: refs, tags, reflogs, FETCH_HEAD/ORIG_HEAD
+            and unreachable objects can make the fix commit (which includes
+            the graded test changes) reachable via ``git log`` / ``git show``,
+          * gitignored build artifacts compiled from the fixed sources
+            (e.g. dist/, lib/, __pycache__) that survive a source checkout
+            of the base commit.
+
+        The scrub pins the repository to the task's base commit on a single
+        local branch, deletes every other ref, expires all reflogs, prunes
+        unreachable objects, removes gitignored build outputs (keeping
+        dependency directories so offline rebuilds still work), and deletes
+        stray patch files. The base commit itself stays reachable, so
+        grade-time ``git checkout <base_sha> <files>`` and
+        ``git diff <base_sha>`` are unaffected.
+        """
+        base_sha = self.pr.base.sha
+        return (
+            "RUN cd /testbed && "
+            "git config --global --add safe.directory /testbed && "
+            f"git reset --hard {base_sha} && "
+            f"git checkout -q -B base {base_sha} && "
+            "for r in $(git for-each-ref --format='%(refname)' refs/heads refs/tags refs/remotes"
+            ' | grep -vx refs/heads/base); do git update-ref -d "$r"; done && '
+            "git reflog expire --all --expire=now && "
+            "rm -f .git/FETCH_HEAD .git/ORIG_HEAD .git/MERGE_HEAD .git/info/grafts && "
+            "rm -rf .git/refs/original && "
+            "git gc --prune=now --quiet && "
+            "git clean -dfX -e node_modules -e .venv -e venv -e vendor && "
+            "rm -f /tmp/*.patch /home/*.patch /home/fix-run.sh && "
+            "(find /tmp -maxdepth 3 -name '*.patch' -delete 2>/dev/null || true)"
+        )
+
     def dockerfile(self) -> str:
         image = self.dependency()
 
-        copy_commands = ""
-        for file in self.files():
-            copy_commands += f"COPY {file.name} /home/\n"
-
+        # Grade-time scripts (fix-run.sh) are intentionally NOT baked into the
+        # image: fix-run.sh embeds the hidden test patch, and the same image is
+        # used to run the agent, so a COPY here would let the agent read the
+        # graded tests. run_evaluation.py bind-mounts the scripts into the
+        # grading container instead (see run_evaluation.py, run_instance).
         return f"""FROM {image}
-{copy_commands}
+{self.sanitize_run_step()}
 
 """
 

--- a/livebench/agentic_code_runner/eval/harness/image.py
+++ b/livebench/agentic_code_runner/eval/harness/image.py
@@ -184,29 +184,45 @@ git checkout {pr.base.sha} {test_files}
             (e.g. dist/, lib/, __pycache__) that survive a source checkout
             of the base commit.
 
-        The scrub pins the repository to the task's base commit on a single
-        local branch, deletes every other ref, expires all reflogs, prunes
-        unreachable objects, removes gitignored build outputs (keeping
-        dependency directories so offline rebuilds still work), and deletes
-        stray patch files. The base commit itself stays reachable, so
-        grade-time ``git checkout <base_sha> <files>`` and
-        ``git diff <base_sha>`` are unaffected.
+        Non-destructive by design (mirrors the validated scrub_v3 in
+        livebench-private): pin the working tree to the base commit, expire
+        reflogs and prune so any dangling fix commit is unrecoverable, and
+        delete stray patch files and the grade script. It deliberately does
+        NOT run ``git clean`` and does NOT sweep refs / re-checkout a branch:
+          * ``git clean -dfX`` deletes gitignored dependency dirs and
+            base-built output that repos which don't rebuild at grade (e.g.
+            nuxt) rely on -- handicapping agent and grader. (And ``-e
+            node_modules`` does NOT protect it: under ``-X`` the ``-e`` pattern
+            is *added* to the ignore set, so node_modules stays in the delete
+            set -- verified.)
+          * a ref sweep + re-checkout desyncs the working tree so the
+            gold/model patch fails to grade (empirically observed: gold went
+            valid=True -> valid=False).
+        Build output (dist/, .nuxt/, ...) is KEPT: images build ``FROM`` the
+        SWE-bench base image, whose dist is base-built and fix-free (verified
+        via dist_leak_check on the base). A compiled-fix in dist only occurs in
+        pipeline-built images and is remediated there by scrub_v3's reliable
+        dist_leak_check (livebench-private), not by a fragile in-Dockerfile
+        grep. node_modules and base output are kept -> no JS/TS handicap; the
+        base commit stays reachable so grade-time ``git checkout <base_sha>
+        <files>`` and ``git diff <base_sha>`` are unaffected. fix-run.sh is not
+        baked (see dockerfile) and is bind-mounted read-only at grade time.
         """
         base_sha = self.pr.base.sha
         return (
             "RUN cd /testbed && "
             "git config --global --add safe.directory /testbed && "
             f"git reset --hard {base_sha} && "
-            f"git checkout -q -B base {base_sha} && "
-            "for r in $(git for-each-ref --format='%(refname)' refs/heads refs/tags refs/remotes"
-            ' | grep -vx refs/heads/base); do git update-ref -d "$r"; done && '
-            "git reflog expire --all --expire=now && "
-            "rm -f .git/FETCH_HEAD .git/ORIG_HEAD .git/MERGE_HEAD .git/info/grafts && "
-            "rm -rf .git/refs/original && "
-            "git gc --prune=now --quiet && "
-            "git clean -dfX -e node_modules -e .venv -e venv -e vendor && "
-            "rm -f /tmp/*.patch /home/*.patch /home/fix-run.sh && "
-            "(find /tmp -maxdepth 3 -name '*.patch' -delete 2>/dev/null || true)"
+            # git-history vector: drop any dangling fix commit (which carries the
+            # graded test changes) via reflog-expire + prune. No ref sweep / no
+            # re-checkout -- those desync the tree and break grading (see docstring).
+            "git reflog expire --expire=now --all 2>/dev/null || true; "
+            "git gc --prune=now --quiet 2>/dev/null || true; "
+            # files vector: stray patches + the grade script (fix-run.sh embeds
+            # the hidden test patch; it is bind-mounted at grade instead of baked).
+            "rm -f /tmp/*.patch /tmp/*.diff /home/*.patch /home/*.diff /home/fix-run.sh /home/*.sh 2>/dev/null || true; "
+            "find /tmp -maxdepth 3 -name '*.patch' -delete 2>/dev/null || true; "
+            "true"
         )
 
     def dockerfile(self) -> str:

--- a/livebench/agentic_code_runner/eval/harness/run_evaluation.py
+++ b/livebench/agentic_code_runner/eval/harness/run_evaluation.py
@@ -768,6 +768,22 @@ class CliArgs:
             )
             return
 
+        # Bind-mount grade-time scripts instead of relying on copies baked
+        # into the task image. fix-run.sh embeds the hidden test patch, and
+        # the same image is used to run the agent, so it must never be part
+        # of the image itself (see SWEImageDefault.dockerfile /
+        # sanitize_run_step in image.py). Mounting also works for older
+        # images that still contain baked copies: the mount shadows them.
+        script_volumes: dict = {}
+        for file in instance.dependency().files():
+            script_path = instance_dir.absolute() / file.name
+            with open(script_path, "w", encoding="utf-8", newline="\n") as f:
+                f.write(file.content)
+            script_volumes[script_path] = {
+                "bind": f"/home/{file.name}",
+                "mode": "ro",
+            }
+
         def run_and_save_output(
             image_full_name: str, run_command: str, output_path: Path
         ):
@@ -783,7 +799,8 @@ class CliArgs:
                     fix_patch_path: {
                         "bind": instance.dependency().fix_patch_path(),
                         "mode": "rw",
-                    }
+                    },
+                    **script_volumes,
                 },
                 timeout=self.instance_timeout,
             )


### PR DESCRIPTION
## Problem
An agent with shell access to the per-task container can read the reference solution directly from the container:
- **Stray patch files** — the reference fix and the hidden test patch are left in `/tmp` (and `/home`) by image preparation. `cat /tmp/fix.patch` returns the gold solution.
- **Git object store** — the fix commit (which also contains the graded test changes) can remain reachable via refs/tags/reflogs/`FETCH_HEAD`, so `git log`/`git show` recover it even when `HEAD` is the base commit.
- **Gitignored build artifacts** — outputs compiled from the fixed sources (`dist/`, `lib/`, `__pycache__`, …) survive a base-commit source checkout, so the fix is grep-able in compiled form.
- **Grading script** — `fix-run.sh` embeds the hidden test patch inline and was `COPY`ed into the *same* image used to run the agent, exposing the graded tests.

(Network egress — re-fetching the fix from upstream — is a related vector, but it is already mitigated by the existing agent-container `--network none` setting; this PR does not touch that.)

## Changes
- **`image.py`** — add `SWEImageDefault.sanitize_run_step()`: a Dockerfile `RUN` that pins the repo to the base commit on a single local branch, deletes all other refs, expires reflogs, removes `FETCH_HEAD`/`ORIG_HEAD`/`MERGE_HEAD`/`refs/original`/grafts, prunes unreachable objects, removes gitignored build outputs (keeping dependency directories so offline rebuilds still work), and deletes stray patch files. `dockerfile()` runs this and no longer `COPY`s grade scripts into the image. The base commit stays reachable, so grade-time `git checkout <base> <files>` and `git diff <base>` are unaffected.
- **`run_evaluation.py`** — bind-mount the grade scripts (`fix-run.sh`) into the grading container at evaluation time instead of baking them into the image, so the hidden test patch never sits in the agent container. (The mount also shadows any baked copies in pre-existing images.)

## Validation
Built hardened images for a TypeScript repo (with `dist/`) and a Python repo (with `__pycache__`) and confirmed inside the built agent image: `/tmp/*.patch`, `/home/fix-run.sh`, and the fixed `dist/` are gone; only the `base` ref remains; 0 dangling objects; `FETCH_HEAD`/`ORIG_HEAD` gone. End-to-end grading via the mounted script still discriminates: base (no patch) → target test **fails** (unresolved), gold fix → target test **passes** (resolved). Agent workflow intact: `git diff` patch extraction works and build artifacts rebuild offline from installed dependencies.

## Follow-up
Repos that override `dockerfile()` should call `sanitize_run_step()` too; a repo whose editable install depends on a gitignored `*.egg-info`/`build/` should be spot-checked against the `git clean -dfX` step.
