### PR TITLE
Fix native tool_calls 400: answer every tool_call_id (pad skipped parallel calls)

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -119,26 +119,56 @@ def _wrap_tool_results(messages: list[dict]) -> None:
             pending_tool_use_id = None
 
 
+# Informative result for a tool_call we did not execute. The chat API requires a
+# role:'tool' reply for EVERY tool_call_id in the preceding assistant turn; we run one
+# command per turn, so extra calls get this. Mirrors mini-swe-agent, which pads skipped
+# calls with returncode -1 + a note rather than a blank — the message also steers the
+# model to stop emitting parallel calls (some providers ignore parallel_tool_calls=False).
+_SKIPPED_TOOL_RESULT = (
+    "<returncode>-1</returncode>\n<output>\n"
+    "[skipped] Parallel tool calls are disabled: only the first command in a turn is "
+    "executed. Issue exactly one command per turn.\n</output>"
+)
+
+
+def _tool_call_ids(msg: dict) -> list:
+    ids = []
+    for tc in (msg.get('tool_calls') or []):
+        tc_id = tc.get('id') if isinstance(tc, dict) else getattr(tc, 'id', None)
+        if tc_id:
+            ids.append(tc_id)
+    return ids
+
+
 def _wrap_tool_results_chat(messages: list[dict]) -> None:
-    """Chat-completions analog of _wrap_tool_results: every user turn that answers
-    an assistant `tool_calls` turn must be a `role:'tool'` message keyed on the
-    tool_call id (OpenAI chat requires each tool_call be answered). One command per
-    turn -> pair to the first tool_call. Mutates a request-only copy in place."""
-    pending_id = None
-    for i, msg in enumerate(messages):
+    """Chat-completions analog of _wrap_tool_results: an assistant `tool_calls` turn
+    must be followed by a `role:'tool'` message for EACH tool_call id (OpenAI chat 400s
+    otherwise: "tool_call_ids did not have response messages"). We execute one command
+    per turn, so the observation answers the FIRST tool_call; any extra tool_calls the
+    model emitted (providers such as Moonshot ignore parallel_tool_calls=False) are
+    padded with an informative 'skipped' tool result keyed to their id — same shape as
+    mini-swe-agent's pad-to-all-ids. Mutates a request-only copy in place."""
+    result = []
+    pending_ids: list = []
+    for msg in messages:
         role = msg.get('role')
         if role == 'assistant':
-            pending_id = None
-            tcs = msg.get('tool_calls')
-            if tcs:
-                tc = tcs[0]
-                pending_id = tc.get('id') if isinstance(tc, dict) else getattr(tc, 'id', None)
-        elif role == 'user' and pending_id is not None:
+            result.append(msg)
+            pending_ids = _tool_call_ids(msg)
+        elif role == 'user' and pending_ids:
             content = msg.get('content')
             if isinstance(content, str):
-                messages[i] = {'role': 'tool', 'tool_call_id': pending_id,
-                               'content': content if content.strip() else '(no output)'}
-            pending_id = None
+                result.append({'role': 'tool', 'tool_call_id': pending_ids[0],
+                               'content': content if content.strip() else '(no output)'})
+                for extra_id in pending_ids[1:]:
+                    result.append({'role': 'tool', 'tool_call_id': extra_id,
+                                   'content': _SKIPPED_TOOL_RESULT})
+            else:
+                result.append(msg)
+            pending_ids = []
+        else:
+            result.append(msg)
+    messages[:] = result
 
 
 def _set_cache_breakpoint(message: dict) -> None:


### PR DESCRIPTION
## Problem

Native agentic runs of glm / kimi / grok (the OpenAI-compatible chat `tool_calls`
path) intermittently die with an empty patch:

```
litellm.BadRequestError: OpenAIException - Invalid request: an assistant message with
'tool_calls' must be followed by tool messages responding to each 'tool_call_id'.
The following tool_call_ids did not have response messages: bash:N
```

Observed on a full kimi-k3 native run: **4 questions** (`jsab-ajv-2192`,
`jsab-mathjs-3585`, `pyab-attrs-1529`, `tsab-marked-3752`) failed this way and
survived all 3 retry rounds (it's deterministic, not transient).

## Root cause

We set `parallel_tool_calls=False`, but **some providers ignore it** (Moonshot
does) and emit multiple `tool_calls` in one assistant turn. The raw assistant
message (with *all* those tool_calls) is stored in history, but on replay
`_wrap_tool_results_chat` answered **only the first** tool_call with a `role:'tool'`
message. The chat API requires a `role:'tool'` reply for **every** `tool_call_id`,
so the un-answered extras 400 the next request → the run ends with no patch.

## Fix

Answer every `tool_call_id`: the observation still answers the first tool_call
(we execute one command per turn), and each extra tool_call is padded with an
informative `role:'tool'` result:

```
<returncode>-1</returncode>
<output>
[skipped] Parallel tool calls are disabled: only the first command in a turn is
executed. Issue exactly one command per turn.
</output>
```

This satisfies the API contract **and** steers the model to stop emitting parallel
calls. It's the same pattern **mini-swe-agent** uses (`format_toolcall_observation_
messages` pads skipped calls with `returncode -1` + a note rather than dropping the
turn); SWE-agent takes the alternative route of rejecting multi-call turns and
re-querying without persisting the `tool_calls`.

## Validation

Unit-tested the wrapper: an assistant turn with 2 tool_calls (`bash:5`, `bash:6`)
followed by one observation now yields **two** `role:'tool'` replies — the first
with the real output, the second with the informative skip — so both ids are
answered and the request is well-formed.

## Scope / follow-up

Fixes the chat `tool_calls` path (glm / kimi / grok). The Anthropic
`_wrap_tool_results` path has the same one-tool_use assumption but has not
reproduced this (Anthropic's direct SDK path / `disable_parallel_tool_use`); a
symmetric pad there is a sensible follow-up if it ever surfaces.
