### PR TITLE
litellm: enable native tool calling for Inkling (Tinker OpenAI-compat chat)

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -868,6 +868,8 @@ class LitellmModel:
             return True
         if ("glm" in mn or "kimi" in mn) and self.config.api_type == "completion":  # GLM (z.ai) / Kimi (moonshot): OpenAI-compatible chat, share the grok tool_calls path (tool_choice=required)
             return True
+        if "inkling" in mn.lower() and self.config.api_type == "completion":     # Thinking Machines Inkling (Tinker OpenAI-compat chat, self-invoking tool_calls); same tool_calls path
+            return True
         if self.config.native_gemini and 'gemini-3' in mn:                      # Gemini genai generate_content (function_call parts)
             return True
         return False


### PR DESCRIPTION
Inkling (Thinking Machines, served via Tinker's OpenAI-compatible chat endpoint) self-invokes function `tool_calls` on agent-style prompts, but it was missing from `_native_tools_enabled()`, so the agentic runner silently fell back to the prompt-based ` ```bash `-text path — no `tool_choice='required'`, no `role:'tool'` result threading, and `native_tool_use_turns` unrecorded.

This adds inkling to the completion-path gate alongside grok/glm/kimi so it takes the identical native `tool_calls` path:

- `tool_choice='required'`
- `parallel_tool_calls=False`
- `role:'tool'` result threading via `_wrap_tool_results_chat` (the pairing-400 pad added in #485)

### Validation

Against the live Tinker endpoint:

- **Protocol smoke** — `tools` + `tool_choice='required'` returns a `bash` tool_call (`finish_reason=tool_calls`, empty content, as the config documents); a follow-up paired `role:'tool'` result is accepted with **no pairing 400**.
- **Harness smoke** (one real agentic question, `pyab-arrow-1222`) — **19/19 native tool turns**, 0 empty responses, patch submitted, question resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
