### PR TITLE
harness: bound chat-completions requests with a timeout (provider-hang guard)

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -31,6 +31,14 @@ class LengthFinishReasonError(Exception):
 
 _DEFAULT_MAX_ATTEMPTS = 15
 LENGTH_FINISH_REASON_MAX_ATTEMPTS = 3
+# Per-request ceiling for the chat-completions path (maps to the httpx read timeout).
+# Without it a provider that accepts the connection but never streams data back
+# (observed with xAI/grok on large-context turns, 2026-07-28) hangs the read forever:
+# the agent instance blocks, and because answers buffer in memory until the round
+# finishes, ONE stuck question stalls the whole run. Bounding the request makes it
+# fail fast -> retry -> error out, so the rest of the run survives. 600s matches the
+# gemini genai path's http timeout; a real completion never legitimately needs longer.
+_REQUEST_TIMEOUT_S = 600
 
 
 def _length_aware_stop(retry_state) -> bool:
@@ -939,6 +947,9 @@ class LitellmModel:
                 actual_kwargs['thinking'] = {'type': 'disabled'}
         if actual_kwargs.get('stream', False) and 'stream_options' not in actual_kwargs:
             actual_kwargs['stream_options'] = {'include_usage': True}
+        # Bound every request so a hung provider stream can't block the run forever
+        # (see _REQUEST_TIMEOUT_S). setdefault so an explicit config timeout wins.
+        actual_kwargs.setdefault('timeout', _REQUEST_TIMEOUT_S)
 
         native = self._native_tools_enabled()
         if native:

--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -39,13 +39,27 @@ LENGTH_FINISH_REASON_MAX_ATTEMPTS = 3
 # fail fast -> retry -> error out, so the rest of the run survives. 600s matches the
 # gemini genai path's http timeout; a real completion never legitimately needs longer.
 _REQUEST_TIMEOUT_S = 600
+# A provider that keeps timing out / refusing the connection will not recover on the
+# 15th try, and each timed-out attempt already burned up to _REQUEST_TIMEOUT_S; cap these
+# low so one bad endpoint can't spend _DEFAULT_MAX_ATTEMPTS x 600s (~2.5h) on a single
+# question and stall the run. Built defensively: only exception classes present in this
+# litellm version are matched (getattr → None otherwise), so it can never AttributeError.
+_TIMEOUT_MAX_ATTEMPTS = 4
+_TIMEOUT_EXC = tuple(c for c in (
+    getattr(litellm.exceptions, "Timeout", None),
+    getattr(litellm.exceptions, "APITimeoutError", None),
+    getattr(litellm.exceptions, "APIConnectionError", None),
+) if isinstance(c, type))
 
 
 def _length_aware_stop(retry_state) -> bool:
-    """tenacity stop: cap LengthFinishReasonError retries, retry everything else normally."""
+    """tenacity stop: cap LengthFinishReasonError + timeout/connection retries early,
+    retry everything else normally."""
     exc = retry_state.outcome.exception() if retry_state.outcome else None
     if isinstance(exc, LengthFinishReasonError):
         return retry_state.attempt_number >= LENGTH_FINISH_REASON_MAX_ATTEMPTS
+    if _TIMEOUT_EXC and isinstance(exc, _TIMEOUT_EXC):
+        return retry_state.attempt_number >= _TIMEOUT_MAX_ATTEMPTS
     return retry_state.attempt_number >= _DEFAULT_MAX_ATTEMPTS
 
 


### PR DESCRIPTION
A run can be taken down by a single provider hang. On 2026-07-28 a grok-4.5 agentic run wedged for hours: 2 large-context astro-TS turns made xAI streaming completion calls that were accepted but never streamed data back. The chat-completions path set **no request timeout**, so each read blocked forever. Because the agentic runner buffers answers in memory until the round finishes, those 2 stuck questions stalled the **entire** run — the 70 already-completed answers were trapped and would have been lost at the job's 6h timeout. (Only the Gemini genai path had a timeout; the completion path did not. The agent's `time_limit`/`step_limit` caps could not fire because they are checked *between* steps, and the thread was frozen *inside* the model call.)

## Fix (two parts)
1. **Bound every request** — `actual_kwargs.setdefault('timeout', _REQUEST_TIMEOUT_S)` (600s, matching the genai path). litellm maps `timeout` to the httpx read timeout, so a stream that sends no data for 600s raises instead of hanging → the thread unblocks → the between-step `time_limit`/`step_limit` caps work again.
2. **Cap timeout/connection retries** — a provider that keeps timing out won't recover on the 15th try, and each attempt already burned up to 600s. `_length_aware_stop` now stops such retries at `_TIMEOUT_MAX_ATTEMPTS=4`, so one bad endpoint can't spend 15×600s (~2.5h) on a single question. Built defensively (only litellm exception classes that exist are matched).

Together: a hung/refusing endpoint fails a question in ≤~40min instead of forever, and the run always completes + grades the rest.

## Context on the other resilience ideas
- The agent's wall-clock (`time_limit: 5400`) and `step_limit: 250` caps already exist in the config — this PR is what re-arms them against in-request hangs.
- **Incremental grading** (grade per-instance as trajectories flush, rather than all-or-nothing after the round) is a larger, separately-tested refactor — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
