### PR TITLE
harness: native tool calling for endpoints that reject a forced tool_choice

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -890,6 +890,8 @@ class LitellmModel:
             return True
         if ("glm" in mn or "kimi" in mn) and self.config.api_type == "completion":  # GLM (z.ai) / Kimi (moonshot): OpenAI-compatible chat, share the grok tool_calls path (tool_choice=required)
             return True
+        if "qwen" in mn and self.config.api_type == "completion":               # Alibaba DashScope OpenAI-compat chat (tool_calls); tool_choice must be 'auto' (thinking mode)
+            return True
         if "inkling" in mn.lower() and self.config.api_type == "completion":     # Thinking Machines Inkling (Tinker OpenAI-compat chat, self-invoking tool_calls); same tool_calls path
             return True
         if self.config.native_gemini and 'gemini-3' in mn:                      # Gemini genai generate_content (function_call parts)
@@ -968,8 +970,9 @@ class LitellmModel:
         native = self._native_tools_enabled()
         if native:
             actual_kwargs['tools'] = [_BASH_TOOL_CHAT]
-            # force a tool call each turn (grok otherwise follows the ```bash-text prompt)
-            actual_kwargs['tool_choice'] = 'required'
+            # force a tool call each turn (grok otherwise follows the ```bash-text prompt);
+            # 'auto' where the provider rejects a forced choice in thinking mode (see helper)
+            actual_kwargs['tool_choice'] = self._native_tool_choice()
             # one command per turn: _wrap_tool_results_chat answers only the first
             # tool_call, so a parallel emission would leave an unanswered tool_call_id
             # and 400 on the next request. Disable parallel calls where the provider
@@ -1076,6 +1079,28 @@ class LitellmModel:
         except Exception:
             return ''
 
+    def _native_tool_choice(self) -> str:
+        """tool_choice for the native tool paths (both Responses and chat-completions):
+        'required' where the provider allows forcing a call, else 'auto'.
+
+        Some providers reject a forced choice while thinking is on — and on these models
+        thinking CANNOT be disabled, so 'required' can never be used there:
+          * DeepSeek's own endpoint  -> 400 "Thinking mode does not support this tool_choice"
+            (api.deepseek.com lists no non-thinking slug)
+          * Alibaba DashScope (qwen3.x-max) -> 400 "The tool_choice parameter does not support
+            being set to required or object in thinking mode" (enable_thinking=False is
+            ignored — reasoning_content comes back regardless)
+        Gated on the ENDPOINT, not the model name: the same DeepSeek weights served by
+        Fireworks DO accept 'required' (verified 200), and keeping the forced choice where it
+        works is strictly better. Under 'auto' these models still emit a bash tool call nearly
+        every turn, so the run stays genuinely native; the text-```bash fallback covers a miss
+        and native_tool_use_turns records the real adherence.
+        """
+        api_base = str(self.config.model_kwargs.get('api_base') or '').lower()
+        if any(h in api_base for h in ('deepseek', 'dashscope', 'aliyuncs')):
+            return 'auto'
+        return 'required'
+
     def _responses_supports_instructions(self) -> bool:
         """Whether the provider's Responses API accepts `instructions` (xAI rejects it)."""
         try:
@@ -1166,7 +1191,7 @@ class LitellmModel:
                 # force a tool call each turn so the run is genuinely native (the shared
                 # instance_template asks for ```bash text, which models otherwise follow);
                 # submit is itself a bash call, so forcing loses nothing.
-                call_kwargs['tool_choice'] = 'required'
+                call_kwargs['tool_choice'] = self._native_tool_choice()
                 call_kwargs['parallel_tool_calls'] = False
             if use_chaining:
                 call_kwargs['store'] = True

--- a/livebench/agentic_code_runner/minisweagent/run_inference.py
+++ b/livebench/agentic_code_runner/minisweagent/run_inference.py
@@ -85,9 +85,16 @@ def run_agentic_coding_inference(
     all_traj_folder = LIVE_BENCH_ROOT_PATH / f"agentic_code_runner/data/trajectories" / run_id
     all_traj_folder.mkdir(parents=True, exist_ok=True)
 
-    # Anthropic models use native tool calling and need the tool-calling prompts
-    # (with tool_choice auto, triple-backtick prompts make models ignore the tool)
-    native_tools = provider == 'anthropic'
+    # Native tool calling needs the tool-calling prompts: under tool_choice='auto' the
+    # triple-backtick instructions in livebench.yaml compete with the tool and models
+    # ignore it. Anthropic always runs native. ALSO required for endpoints that REJECT a
+    # forced tool_choice while thinking is on — DashScope/qwen and DeepSeek's own API both
+    # 400 with "does not support being set to required ... in thinking mode" — because
+    # there the prompt template is the only lever left. Measured on qwen3.8-max under the
+    # text prompts: it called the bash tool on just 19/72 questions.
+    _no_forced_tool_choice = any(h in str(provider).lower()
+                                 for h in ('dashscope', 'aliyuncs', 'deepseek'))
+    native_tools = provider == 'anthropic' or _no_forced_tool_choice
     config_name = "livebench_native.yaml" if native_tools else "livebench.yaml"
     if native_tools:
         print(f"Native tool-calling mode ON: using {config_name}")


### PR DESCRIPTION
Some providers **400 on `tool_choice='required'` while thinking is on**, and on those models thinking cannot be disabled — so `required` can never be used there:

- **Alibaba DashScope** (qwen3.x-max): *"The tool_choice parameter does not support being set to required or object in thinking mode"* (`extra_body.enable_thinking=False` is ignored — `reasoning_content` comes back regardless)
- **api.deepseek.com**: *"Thinking mode does not support this tool_choice"*

Before this, such a model could not run agentic_coding_v2 natively at all.

## Changes

Both are gated on the **endpoint**, not the model name, so the same weights served elsewhere keep the stricter setting.

1. **`_native_tool_choice()`** (`litellm_model.py`) — returns `auto` when `api_base` matches deepseek/dashscope/aliyuncs, else `required`. Used by **both** native paths (chat-completions and Responses). DeepSeek served by Fireworks still gets `required` (verified 200).
2. **`run_inference.py`** — extends native **prompt** selection (`livebench_native.yaml`) beyond Anthropic to those same endpoints.

Plus qwen added to `_native_tools_enabled()` for the completion path.

## Why (2) is the load-bearing half

Under `tool_choice=auto` the triple-backtick instructions in `livebench.yaml` compete with the tool, and the model follows the prompt instead of calling it. The prompt template is the only remaining lever. Measured on **qwen3.8-max**, agentic_coding_v2:

| | text prompts | native prompts |
|---|---|---|
| native tool adherence | 19/72 (26%) | **72/72 (100%)** |
| exit `Submitted` | 56/72 | **72/72** |
| hit a limit | 16/72 (all time-cap) | **0/72** |
| **score** | 35/72 | **46/72** |

The 16 "time cap" failures were an artifact of the wrong prompt template, not model slowness — those same questions completed in roughly a third of the wall-clock once the model actually used the tool.

## Comparability note

This makes qwen / DeepSeek-native rows directly comparable to the **Anthropic** rows (same template) but **not** to grok/glm/kimi/gemini/OpenAI, which run text prompts with forced `tool_choice`. Those models are forced into native calls regardless, so their handicap is mild prompt mismatch rather than tool avoidance — I would not extrapolate qwen's +11 to them without measuring it.

Required to reproduce the published **Qwen 3.8 Max** board row (46/72 agentic); without it a clean checkout reruns qwen prompt-based and scores ~35/72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
