### PR TITLE
completions: honor stream: true on the Responses path

### DIFF
--- a/livebench/model/completions.py
+++ b/livebench/model/completions.py
@@ -225,14 +225,37 @@ def chat_completion_openai_responses(model: str, messages: Conversation, tempera
 
     output_text = 'BLOCKED'
     output_tokens = 1
+    # Stream when asked (function arg or `stream: true` in the model config's api_kwargs).
+    # A non-streamed Responses call must finish inside the provider's gateway timeout, so a
+    # model that spends 10+ minutes on one answer dies with "upstream request timeout" and is
+    # graded 0 — observed on deepseek-v4-flash-0731 via Fireworks, where the longest tasks
+    # (consecutive_events) failed 74% of the time. Streaming keeps bytes flowing (first token
+    # in <1s), so the request survives; the final response object is identical either way.
+    want_stream = bool(actual_api_kwargs.pop('stream', False)) or stream
     try:
-        response = client.responses.create(
-            model=model,
-            instructions=developer_message,
-            input=input,
-            store=False,
-            **actual_api_kwargs
-        )
+        if want_stream:
+            response = None
+            for event in client.responses.create(
+                model=model,
+                instructions=developer_message,
+                input=input,
+                store=False,
+                stream=True,
+                **actual_api_kwargs
+            ):
+                # the terminal event carries the assembled response (text + usage)
+                if getattr(event, 'type', '') in ('response.completed', 'response.incomplete'):
+                    response = getattr(event, 'response', None)
+            if response is None:
+                raise Exception("Stream ended without a completed response event")
+        else:
+            response = client.responses.create(
+                model=model,
+                instructions=developer_message,
+                input=input,
+                store=False,
+                **actual_api_kwargs
+            )
 
         if response is None:
             raise Exception("No response received from OpenAI Responses")


### PR DESCRIPTION
Honors `stream: true` on the Responses path. Today `chat_completion_openai_responses` always makes a non-streamed call, so a `stream: true` in a model config's `api_kwargs` is silently dropped (and would in fact be passed through as an unexpected kwarg).

A non-streamed Responses call has to finish inside the provider's gateway timeout. A model that spends 10+ minutes on one answer therefore dies with `upstream request timeout` and is graded 0 regardless of answer quality. Streaming keeps bytes flowing (first token in <1s) so the request survives; the terminal `response.completed` / `response.incomplete` event carries the same assembled response object, so nothing downstream changes.

## Scope — please do not over-read this

**This does not fix the Fireworks long-generation cutoff.** The published deepseek-v4-flash-0731 run still took an `api_error` Timeout on one question (BigCodeBench/945: 0 output tokens, `total_time_s` 7200 across two 3600s attempts). Streaming reduces the failure rate on long generations but does not eliminate it — that run ultimately needed a faster serving route, not this patch.

Merge this as a small correctness fix — the config flag should do what it says — rather than as a fix for that failure mode.

## Behaviour

- `want_stream` = `stream` argument **or** `stream: true` popped from the config's `api_kwargs`
- non-streaming remains the default, so existing models are unaffected
- if the stream ends without a terminal event, raises rather than returning a partial answer silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
