### PR TITLE
configs: add glm-5.2 cached_input; correct a wrong cost claim from #493

### DIFF
--- a/livebench/model/model_configs/deepseek.yml
+++ b/livebench/model/model_configs/deepseek.yml
@@ -212,14 +212,17 @@ api_kwargs:
 # accepts tool_choice='required', so the agentic native path needs no special casing.
 display_name: deepseek-v4-flash-0731-fw
 # DeepSeek's published token rates ($0.14 in / $0.28 out). The cache rate is the SERVING
-# provider's, not DeepSeek's, and it is EMPIRICALLY DERIVED, not published: solving for the
-# cached rate that reproduces the summed provider-reported `cost_usd` over the 72 agentic
-# answers gives $0.0280/1M exactly (= 0.200 x input; computed $53.8981 vs reported $53.8981,
-# delta $0.0000). Do NOT "correct" this to either of the tempting alternatives:
-#   * DeepSeek's own $0.003 cache-hit rate -> $46.77, 13.2% UNDER actual (that rate applies
-#     only to api.deepseek.com; see the -ds entry below)
-#   * Fireworks' documented default 50% discount ($0.07) -> $65.87, 22.2% OVER actual
-# Re-derive it the same way if the provider changes rates.
+# provider's (Fireworks), not DeepSeek's — the same weights on api.deepseek.com bill cache
+# reads 10x cheaper (see the -ds entry).
+# ⚠️ 0.028 (= 0.2x input) is an ESTIMATE, not a verified rate. It is consistent with the
+# per-model cached rates Fireworks publishes for comparable slugs (GLM-5.2 0.1x, Kimi-K2.6
+# 0.17x, MiniMax-M3 0.20x), but Fireworks publishes no cached rate for this slug.
+# CORRECTION (2026-08-04): an earlier version of this comment claimed 0.028 was derived by
+# reconciling against provider-reported cost. That was WRONG and the reasoning was circular:
+# `cost_usd` in the answer records is computed BY THE HARNESS from this very config
+# (gen_api_answer.py / run_inference.py), so it can never validate the config. There is no
+# independent billing figure anywhere in the pipeline. Replace this with a real invoice
+# number or a published rate when one is available.
 cost_per_million:
   input: 0.14
   cached_input: 0.028

--- a/livebench/model/model_configs/zai.yml
+++ b/livebench/model/model_configs/zai.yml
@@ -126,8 +126,16 @@ api_kwargs:
 preserve_reasoning: true
 ---
 display_name: glm-5.2
+# Published z.ai rates (docs.z.ai/guides/overview/pricing, verified 2026-08-04): $1.40 in /
+# $4.40 out, cached input $0.26/1M (an 81% discount; cache storage is free for now).
+# cached_input is REQUIRED, not optional: the harness only credits cache reads when the key
+# is present (`cached = total_cached_tokens if 'cached_input' in cpm else 0`), so omitting it
+# bills every cache read at the FULL input rate. glm-5.2 runs ~98% cache reads
+# (298.5M of 305.2M input tokens on agentic_coding_v2), so leaving it out overstated the
+# agentic cost as $445 instead of ~$105 — a 4.2x error.
 cost_per_million:
   input: 1.4
+  cached_input: 0.26
   output: 4.4
 api_name:
   https://api.z.ai/api/paas/v4: glm-5.2


### PR DESCRIPTION
Two fixes to cached-input accounting, plus a correction to a claim I got wrong in #493.

## 1. `glm-5.2` was missing `cached_input` entirely

The harness only credits cache reads when the key is present:

```python
cached = total_cached_tokens if 'cached_input' in cpm else 0
```

So every cache read was billed at the **full input rate**. glm-5.2 runs ~98% cache reads on agentic_coding_v2 (298.5M of 305.2M input tokens), which reported its agentic cost as **$445 instead of ~$105 — a 4.2x overstatement.**

Fixed with z.ai's published rate: **$0.26/1M** (81% off the $1.40 input; cache storage free for now, per docs.z.ai/guides/overview/pricing, verified 2026-08-04).

Note this is an *accounting* bug only — prompt caching was already active and working on those runs. Nothing needs re-running to benefit from it.

## 2. Correcting a wrong claim from #493

The `deepseek-v4-flash-0731-fw` comment I merged asserted that `cached_input: 0.028` had been validated by reconciling against provider-reported cost ("computed $53.8981 vs reported $53.8981, delta $0.0000").

**That reasoning was circular.** `cost_usd` in the answer records is computed *by the harness from this very config* (`gen_api_answer.py:127-137`, `run_inference.py:269-282`) — it can never validate the config it came from. There is **no independent billing figure anywhere in the pipeline**; `instance_cost` is litellm's estimate and is overwritten whenever `cost_per_million` exists.

The value is left at 0.028 but is now labelled an **estimate**, justified only by consistency with the per-model cached rates Fireworks publishes for comparable slugs (GLM-5.2 0.1x, Kimi-K2.6 0.17x, MiniMax-M3 0.20x). It should be replaced with a real invoice number or a published rate when one exists.

The same circularity warning applies to any future "I reconciled the cost" claim — worth knowing before someone repeats it.

## Still missing `cached_input`: 26 other configs

Audited all 141 priced configs. Board-relevant ones that still guess:

| model | input | file |
|---|---|---|
| kimi-k2.6-thinking, kimi-k2.7-code | 0.95 | moonshotai.yml |
| qwen3.7-max | 2.5 | qwen.yml |
| qwen3.6-plus, qwen3.6-plus-responses | 0.5 | qwen.yml |
| qwen3.6-27b | 0.6 | qwen.yml |
| gpt-5.2-pro (medium/high/xhigh) | 21 | openai.yml |
| gpt-5-pro, o3-pro, o1-pro | 15 / 20 / 150 | openai.yml |

Not fixed here because I would only be guessing, and the observed spread across providers is wide — kimi-k3 0.100x, qwen3.8-max 0.125x, glm-5.2 0.186x, deepseek-v4-flash 0.020x. Each needs its provider's published rate looked up. The remaining ~14 are legacy gpt-3.5/gpt-4 models that predate prompt caching, where absence is arguably correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
