### PR TITLE
configs: fix grok-4.5 cache rate; add verified rates for kimi-k2.x and qwen3.7-max

### DIFF
--- a/livebench/model/model_configs/moonshotai.yml
+++ b/livebench/model/model_configs/moonshotai.yml
@@ -58,8 +58,12 @@ api_kwargs:
 preserve_reasoning: true
 ---
 display_name: kimi-k2.6-thinking
+# Published Moonshot rates (verified 2026-08-04): $0.95 cache-miss input / $0.19 cache-hit /
+# $4.00 output = 0.20x. NOTE this is NOT kimi-k3's ratio: k3 is $3.00/$0.30/$15.00 = 0.10x.
+# Moonshot's cache discount differs per model generation -- never carry one model's rate over.
 cost_per_million:
   input: 0.95
+  cached_input: 0.19
   output: 4
 api_name:
   https://api.moonshot.ai/v1: kimi-k2.6
@@ -77,8 +81,12 @@ api_kwargs:
 preserve_reasoning: true
 ---
 display_name: kimi-k2.7-code
+# Published Moonshot rates (verified 2026-08-04): $0.95 cache-miss input / $0.19 cache-hit /
+# $4.00 output = 0.20x. NOTE this is NOT kimi-k3's ratio: k3 is $3.00/$0.30/$15.00 = 0.10x.
+# Moonshot's cache discount differs per model generation -- never carry one model's rate over.
 cost_per_million:
   input: 0.95
+  cached_input: 0.19
   output: 4
 api_name:
   https://api.moonshot.ai/v1: kimi-k2.7-code

--- a/livebench/model/model_configs/qwen.yml
+++ b/livebench/model/model_configs/qwen.yml
@@ -247,8 +247,14 @@ api_kwargs:
       enable_thinking: true
 ---
 display_name: qwen3.7-max
+# Published Alibaba Model Studio rates (verified 2026-08-04): $2.50 input / $7.50 output,
+# IMPLICIT cache read $0.25/1M. Alibaba prices the two cache modes differently -- implicit
+# $0.25 vs explicit $0.125 -- and LiveBench does not wire explicit context caching, so the
+# IMPLICIT rate is the correct one to bill at. (Same reasoning as qwen3.8-max, which is also
+# $0.25 implicit.) Do not substitute the cheaper explicit rate.
 cost_per_million:
   input: 2.5
+  cached_input: 0.25
   output: 7.5
 api_name:
   https://dashscope-intl.aliyuncs.com/compatible-mode/v1: qwen3.7-max

--- a/livebench/model/model_configs/xai.yml
+++ b/livebench/model/model_configs/xai.yml
@@ -169,9 +169,15 @@ api_name:
   https://api.x.ai/v1: grok-4.5
 api_keys:
   https://api.x.ai/v1: XAI_API_KEY
+# Published xAI rates (docs.x.ai/docs/models, verified 2026-08-04): $2.00 in / $0.30 cached /
+# $6.00 out for prompts under 200k tokens. cached was 0.50 (0.25x) -- 67% too high; the
+# documented ratio is 0.15x. grok-4.3 (1.25/0.20/2.50) and grok-build-0.1 (1.00/0.20/2.00)
+# are correct as written: the ratio genuinely differs per model, so do NOT normalise them.
+# Not modelled: prompts >= 200k tokens bill at 2x every rate ($4.00/$0.60/$12.00), so
+# long-context runs are understated. cost_per_million has no tier concept.
 cost_per_million:
   input: 2.00
-  cached_input: 0.50
+  cached_input: 0.30
   output: 6.00
 ---
 display_name: grok-4-fast-reasoning-responses


### PR DESCRIPTION
Audited the `cached_input` rate of **every model with a board row** against provider documentation. Three changes; everything else verified correct and left alone.

## Changes

| model | before | after | source |
|---|---|---|---|
| **grok-4.5** | 0.50 (0.25x) | **0.30** (0.15x) | xAI documents $2.00 / $0.30 / $6.00 — 0.50 was **67% too high** |
| **kimi-k2.6-thinking** | missing | **0.19** (0.20x) | Moonshot: $0.95 cache-miss / $0.19 cache-hit / $4.00 |
| **kimi-k2.7-code** | missing | **0.19** (0.20x) | same |
| **qwen3.7-max** | missing | **0.25** (0.10x) | Alibaba implicit cache read |

On qwen: Alibaba prices the two cache modes differently — **implicit $0.25 vs explicit $0.125** — and LiveBench does not wire explicit context caching, so the implicit rate is the correct one to bill at (matching qwen3.8-max). This is the one provider where the implicit/explicit distinction genuinely changes the number.

## Verified correct — no change

- **Gemini** 3.1-pro 2/0.2/12, 3.5-flash 1.5/0.15/9, 3.5-flash-lite 0.3/0.03/2.5, 3.6-flash 1.5/0.15/7.5 — all 0.1x, and Google prices caching uniformly with no implicit/explicit split
- **DeepSeek** v4-flash 0.14/0.0028/0.28, v4-pro 0.435/0.0036/0.87 (0.003625 rounded) — the very different ratios (0.020x vs 0.008x) are genuine, not an inconsistency
- **Moonshot** kimi-k3 3/0.3/15 (0.1x, no length tiering)
- **OpenAI** gpt-5.4/5.5/5.6 all 0.1x — sol 5/0.5/30, gpt-5.5 5/0.5/30, gpt-5.4 2.5/0.25/15, mini 0.75/0.075/4.5, nano 0.2/0.02/1.25. The **pro** and **o1/o3-pro** models offer no cached rate at all, so their missing key is correct and adding one would introduce an error
- **Anthropic** 0.1x read + 1.25x write, matching Anthropic's documented structure
- **xAI** grok-4.3 (0.16x) and grok-build-0.1 (0.20x) — correct as written

Observed ratios now span **0.10x to 0.20x**, which is why a single 0.1x default is wrong more often than not (new-livebench#13 makes that default warn).

## Not addressed here

- **Long-context tiers.** xAI doubles every rate above 200k prompt tokens; Gemini 3.1-pro doubles above 200k; OpenAI 5.4/5.5/5.6 have long-context tiers too. `cost_per_million` has no tier concept, so long-context runs are understated across the board.
- **Three board rows have no `cost_per_million` at all** — claude-opus-5-max-effort, claude-opus-4-8-max-effort, deepseek-v4-flash-0731 — so their rows were built from explicit price flags and cannot be regenerated from config.
- **Gemini context-cache storage** ($1.00–4.50 per 1M/hour) is not modelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)