### PR TITLE
harness: explicit native-tools opt-in; warn instead of silently degrading

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -2,6 +2,7 @@ import copy
 import json
 import logging
 import os
+import sys
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -39,6 +40,9 @@ LENGTH_FINISH_REASON_MAX_ATTEMPTS = 3
 # fail fast -> retry -> error out, so the rest of the run survives. 600s matches the
 # gemini genai path's http timeout; a real completion never legitimately needs longer.
 _REQUEST_TIMEOUT_S = 600
+# Models already warned about running prompt-based, so the notice appears once per model
+# per process instead of once per question.
+_WARNED_PROMPT_BASED: set[str] = set()
 # A provider that keeps timing out / refusing the connection will not recover on the
 # 15th try, and each timed-out attempt already burned up to _REQUEST_TIMEOUT_S; cap these
 # low so one bad endpoint can't spend _DEFAULT_MAX_ATTEMPTS x 600s (~2.5h) on a single
@@ -228,6 +232,12 @@ class LitellmModelConfig:
     # gemini-3 via the Interactions API (explicit content_blocked / incomplete
     # statuses instead of finish_reason guessing); False falls back to generateContent
     gemini_interactions: bool = True
+    # Explicit native-tool override, set from the model config's `native_tools:`.
+    # None = decide by family (the list in _native_tools_enabled). True/False wins
+    # outright. Needed because that list matches on SUBSTRINGS of the model name, so a
+    # finetune served under its own name ("k3-v3sft" off a kimi-k3 base) silently misses
+    # the family it belongs to and runs prompt-based.
+    native_tools: bool | None = None
 
 class LitellmModel:
     def __init__(self, **kwargs):
@@ -879,8 +889,22 @@ class LitellmModel:
         # One uniform switch across all families (default on). Each family exposes the
         # SAME bash tool via its provider-native schema + tool_choice='auto', with a
         # graceful text-```bash fallback; native_tool_use_turns records actual adherence.
-        if os.getenv("MSWEA_NATIVE_TOOLS", "1") != "1":
+        env = os.getenv("MSWEA_NATIVE_TOOLS", "1")
+        # Explicit overrides beat family detection, in precedence order:
+        #   MSWEA_NATIVE_TOOLS=0      -> off for everything (existing kill switch)
+        #   MSWEA_NATIVE_TOOLS=force  -> on regardless of family
+        #   config `native_tools:`    -> per-model, the durable way to say it
+        # The family list below matches on SUBSTRINGS of the model name, which silently
+        # fails for any model not named after its family — a kimi-k3 finetune served as
+        # "k3-v3sft" contains neither "kimi" nor "glm", so it drops to prompt-based and
+        # scores far lower for interface reasons that look like model quality. Set
+        # `native_tools: true` rather than renaming the model to game the substring.
+        if env == "force":
+            return True
+        if env != "1":
             return False
+        if self.config.native_tools is not None:
+            return self.config.native_tools
         mn = self.config.model_name
         if 'anthropic' in mn:                                                   # Anthropic direct SDK (tool_use)
             return True
@@ -896,6 +920,23 @@ class LitellmModel:
             return True
         if self.config.native_gemini and 'gemini-3' in mn:                      # Gemini genai generate_content (function_call parts)
             return True
+        # No family matched. This is a legitimate outcome (deepseek is prompt-based by
+        # design), but it is also what an unrecognised finetune looks like — and the two
+        # are indistinguishable from the score alone, since a prompt-based run just scores
+        # lower rather than failing. Say so once, loudly, so nobody has to notice.
+        global _WARNED_PROMPT_BASED
+        if mn not in _WARNED_PROMPT_BASED:
+            _WARNED_PROMPT_BASED.add(mn)
+            print(
+                f"WARNING: '{mn}' is running PROMPT-BASED (no native tool calls). The family "
+                f"check matches on substrings of the model name, so a finetune or a custom "
+                f"endpoint name misses its family even when the underlying model supports "
+                f"tools. If it does, set `native_tools: true` in the model config (or run "
+                f"with MSWEA_NATIVE_TOOLS=force) — measured on qwen3.8-max the same model "
+                f"scored 35/72 prompt-based vs 46/72 native. If this model is genuinely "
+                f"prompt-based, set `native_tools: false` to silence this.",
+                file=sys.stderr,
+            )
         return False
 
     def _needs_direct_anthropic_call(self) -> bool:

--- a/livebench/agentic_code_runner/minisweagent/run_inference.py
+++ b/livebench/agentic_code_runner/minisweagent/run_inference.py
@@ -135,6 +135,14 @@ def run_agentic_coding_inference(
     if preserve_reasoning:
         config['model']['preserve_reasoning'] = True
 
+    # Explicit native-tool opt-in/out from the model config. Without this, the family
+    # check in _native_tools_enabled matches on substrings of the model name, so a
+    # finetune or a custom-endpoint name silently misses its family and runs
+    # prompt-based — which shows up as a much lower score, not as an error.
+    native_tools_override = getattr(model_config, 'native_tools', None)
+    if native_tools_override is not None:
+        config['model']['native_tools'] = native_tools_override
+
     config_path = all_traj_folder / 'config.yaml'
     with open(config_path, 'w') as f:
         yaml.dump(config, f)

--- a/livebench/model/api_model_config.py
+++ b/livebench/model/api_model_config.py
@@ -25,6 +25,7 @@ class ModelConfig:
     preserve_reasoning: bool | None = None # whether to preserve reasoning in multi-turn tasks
     cost_per_million: dict[str, float] | None = None # USD per 1M tokens; keys: input, cached_input, output
     api_base: str | None = None # explicit base URL for the provider (e.g. non-OpenAI Responses API endpoints like Meta)
+    native_tools: bool | None = None # force native tool calling on/off for agentic runs; None = decide by model family. Set true for finetunes/custom endpoints whose NAME doesn't contain its family (e.g. a kimi-k3 finetune served as "k3-v3sft"), which would otherwise silently run prompt-based and score far lower.
 
 @cache
 def load_model_configs(file_path: str) -> dict[str, ModelConfig]:


### PR DESCRIPTION
`_native_tools_enabled()` decides by **substring of the model name** (`"kimi" in mn`, `"glm" in mn`, …). Any model not named after its family misses it — a kimi-k3 finetune served as `k3-v3sft` contains neither `"kimi"` nor `"glm"` — and drops to prompt-based.

**That doesn't fail. It just scores much lower**, and the deficit looks like model quality. Someone evaluating a K3 finetune hit exactly this and reported it as the finetune underperforming its base.

The interface is worth a lot — measured on qwen3.8-max, the same model scored **35/72 prompt-based vs 46/72 native**, with time-cap failures going 16 → 0.

## What this adds

An explicit override, in precedence order:

| | |
|---|---|
| `MSWEA_NATIVE_TOOLS=0` | off for everything (existing kill switch, unchanged) |
| `MSWEA_NATIVE_TOOLS=force` | on regardless of family — for quick one-off runs |
| **`native_tools:` in the model config** | per-model, the durable way to say it |
| *(unset)* | decide by family, exactly as before |

And when no family matches, a **one-time warning** naming the model and how to enable it. A legitimately prompt-based model (deepseek is prompt-based by design) silences it with `native_tools: false`.

```
WARNING: 'k3-v3sft' is running PROMPT-BASED (no native tool calls). The family check
matches on substrings of the model name, so a finetune or a custom endpoint name misses
its family even when the underlying model supports tools. If it does, set
`native_tools: true` in the model config (or run with MSWEA_NATIVE_TOOLS=force) —
measured on qwen3.8-max the same model scored 35/72 prompt-based vs 46/72 native.
```

## What this deliberately does NOT do

**It doesn't flip the default to on-for-everything**, which was the tempting fix. Two reasons:

1. Sending `tools` to an endpoint that doesn't support them **400s**, and there's no runtime fallback on that path — only `InternalServerError` for context-length is caught. A blanket flip converts silent degradation into hard failures for unknown endpoints.
2. It would change the interface for **already-published rows** (deepseek is prompt-based by design), making them unreproducible.

Every existing model's behaviour here is byte-identical. This only adds a way to say "yes, this one too".

The genuinely correct long-term fix is native-by-default *with* a runtime fallback that catches the tools-unsupported 400, disables native for that model, and records that it happened. That's a bigger change and worth doing separately.

## Verification

All six precedence paths tested:

| case | result |
|---|---|
| `kimi-k3` (family match) | True — unchanged |
| `k3-v3sft`, no override | False + warns once |
| `k3-v3sft`, `native_tools: true` | True |
| `kimi-k3`, `native_tools: false` | False |
| `k3-v3sft`, `MSWEA_NATIVE_TOOLS=force` | True |
| `kimi-k3`, `MSWEA_NATIVE_TOOLS=0` | False — kill switch still wins |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
