### PR TITLE
harness: Meta rejects a forced tool_choice — route it to 'auto' + native prompts

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -1097,7 +1097,13 @@ class LitellmModel:
         and native_tool_use_turns records the real adherence.
         """
         api_base = str(self.config.model_kwargs.get('api_base') or '').lower()
-        if any(h in api_base for h in ('deepseek', 'dashscope', 'aliyuncs')):
+        #   * Meta (api.meta.ai, muse-spark) -> 400 'only `"auto"` is supported for
+        #     `tool_choice`. `"none"`, `"required"`, and named function choices are not
+        #     currently supported'. Note muse-spark-1.1 DID run with a forced choice
+        #     (26/26 native turns on its published run), so Meta tightened this after that
+        #     run -- a provider's accepted params can regress between model releases, and
+        #     the failure is a hard 400 that kills the question, not a silent downgrade.
+        if any(h in api_base for h in ('deepseek', 'dashscope', 'aliyuncs', 'meta.ai')):
             return 'auto'
         return 'required'
 

--- a/livebench/agentic_code_runner/minisweagent/run_inference.py
+++ b/livebench/agentic_code_runner/minisweagent/run_inference.py
@@ -92,8 +92,15 @@ def run_agentic_coding_inference(
     # 400 with "does not support being set to required ... in thinking mode" — because
     # there the prompt template is the only lever left. Measured on qwen3.8-max under the
     # text prompts: it called the bash tool on just 19/72 questions.
-    _no_forced_tool_choice = any(h in str(provider).lower()
-                                 for h in ('dashscope', 'aliyuncs', 'deepseek'))
+    # Match on the api_base too, not just the provider string: a model reached through an
+    # explicit base URL arrives here as provider='openai_responses'/'openai', so a
+    # provider-only check silently misses it. Meta (api.meta.ai, muse-spark) is exactly
+    # that case -- it 400s on a forced tool_choice, so it needs 'auto', and 'auto' WITHOUT
+    # the native prompts is the qwen failure mode: the triple-backtick instructions win and
+    # the model ignores the tool (19/72 questions on qwen3.8-max).
+    _NO_FORCED_TOOL_CHOICE_HOSTS = ('dashscope', 'aliyuncs', 'deepseek', 'meta.ai')
+    _endpoint = f"{provider} {(api_dict or {}).get('api_base', '')}".lower()
+    _no_forced_tool_choice = any(h in _endpoint for h in _NO_FORCED_TOOL_CHOICE_HOSTS)
     native_tools = provider == 'anthropic' or _no_forced_tool_choice
     config_name = "livebench_native.yaml" if native_tools else "livebench.yaml"
     if native_tools:


### PR DESCRIPTION
`api.meta.ai` (muse-spark) now **400s on a forced `tool_choice`**:

```
only `"auto"` is supported for `tool_choice`. `"none"`, `"required"`, and
named function choices are not currently supported
```

That kills every agentic question outright — the smoke came back `exit=BadRequestError` with **0 api_calls**.

Worth flagging: **`muse-spark-1.1` DID run with a forced choice** (26/26 native turns on its published row), so Meta tightened this *after* that run. A provider's accepted parameters can regress between model releases, and here it fails hard rather than degrading quietly.

## Two changes — the first alone would have been worse than useless

**1. `_native_tool_choice`** — add `meta.ai` to the hosts that get `'auto'`, alongside deepseek/dashscope/aliyuncs.

**2. `run_inference`** — select the native **prompt template** by matching the `api_base` too, not just the provider string.

A model reached through an explicit base URL arrives as `provider='openai_responses'`, so the provider-only check could **never** see Meta. Without (2), fix (1) produces `auto` **with the text prompts** — precisely the qwen failure mode, where the triple-backtick instructions beat the tool and the model stops calling it (**19/72** questions on qwen3.8-max). That wouldn't error. It would just silently score low, which is the harder bug to ever notice.

## Verified on a live agentic smoke (muse-spark-1.2)

| | before | after |
|---|---|---|
| exit status | `BadRequestError` | **`Submitted`** |
| native turns | 0 / 0 | **49 / 49** |
| wall clock | — | 133s |
| prompt template | text (`EXACTLY ONE BASH BLOCK`) | native (``EXACTLY ONE `bash` tool call``) |

Routing is unchanged everywhere else — `meta.ai` / `dashscope` / `deepseek` → `auto`; `fireworks` / `moonshot` / `xai` → `required`.

## Related

Complements #498 (explicit `native_tools:` opt-in + a warning when a run silently ends up prompt-based). This PR fixes a provider that *should* be native and hard-fails; #498 covers the case where a model should be native and quietly isn't. Both are the same underlying weakness: native-tool eligibility is inferred from strings rather than declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
