### PR TITLE
reasoning: count reasoning tokens (regular + agentic), and persist reasoning text

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -1097,7 +1097,13 @@ class LitellmModel:
         and native_tool_use_turns records the real adherence.
         """
         api_base = str(self.config.model_kwargs.get('api_base') or '').lower()
-        if any(h in api_base for h in ('deepseek', 'dashscope', 'aliyuncs')):
+        #   * Meta (api.meta.ai, muse-spark) -> 400 'only `"auto"` is supported for
+        #     `tool_choice`. `"none"`, `"required"`, and named function choices are not
+        #     currently supported'. Note muse-spark-1.1 DID run with a forced choice
+        #     (26/26 native turns on its published run), so Meta tightened this after that
+        #     run -- a provider's accepted params can regress between model releases, and
+        #     the failure is a hard 400 that kills the question, not a silent downgrade.
+        if any(h in api_base for h in ('deepseek', 'dashscope', 'aliyuncs', 'meta.ai')):
             return 'auto'
         return 'required'
 

--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -1046,7 +1046,14 @@ class LitellmModel:
         if res and res.choices and len(res.choices) > 0:
             result['content'] = content
             result['input_tokens'] = res.usage.prompt_tokens
-            result['output_tokens'] = res.usage.completion_tokens
+            # Reasoning bills as OUTPUT but sits outside completion_tokens, under
+            # completion_tokens_details.reasoning_tokens. Without this, a thinking model's
+            # agentic cost is understated by its whole reasoning trace (xAI grok-4.6:
+            # completion=237 vs reasoning=1901 on one call). Same defect that affected the
+            # regular path in completions.py.
+            _ctd = getattr(res.usage, 'completion_tokens_details', None)
+            _reasoning = getattr(_ctd, 'reasoning_tokens', None) if _ctd is not None else None
+            result['output_tokens'] = (res.usage.completion_tokens or 0) + (_reasoning or 0)
             # OpenAI/Anthropic report cache reads under prompt_tokens_details; Gemini-via-litellm
             # uses a top-level field, read only as a fallback to avoid double-counting.
             result['cached_tokens'] = (

--- a/livebench/agentic_code_runner/minisweagent/run_inference.py
+++ b/livebench/agentic_code_runner/minisweagent/run_inference.py
@@ -92,8 +92,15 @@ def run_agentic_coding_inference(
     # 400 with "does not support being set to required ... in thinking mode" — because
     # there the prompt template is the only lever left. Measured on qwen3.8-max under the
     # text prompts: it called the bash tool on just 19/72 questions.
-    _no_forced_tool_choice = any(h in str(provider).lower()
-                                 for h in ('dashscope', 'aliyuncs', 'deepseek'))
+    # Match on the api_base too, not just the provider string: a model reached through an
+    # explicit base URL arrives here as provider='openai_responses'/'openai', so a
+    # provider-only check silently misses it. Meta (api.meta.ai, muse-spark) is exactly
+    # that case -- it 400s on a forced tool_choice, so it needs 'auto', and 'auto' WITHOUT
+    # the native prompts is the qwen failure mode: the triple-backtick instructions win and
+    # the model ignores the tool (19/72 questions on qwen3.8-max).
+    _NO_FORCED_TOOL_CHOICE_HOSTS = ('dashscope', 'aliyuncs', 'deepseek', 'meta.ai')
+    _endpoint = f"{provider} {(api_dict or {}).get('api_base', '')}".lower()
+    _no_forced_tool_choice = any(h in _endpoint for h in _NO_FORCED_TOOL_CHOICE_HOSTS)
     native_tools = provider == 'anthropic' or _no_forced_tool_choice
     config_name = "livebench_native.yaml" if native_tools else "livebench.yaml"
     if native_tools:

--- a/livebench/gen_api_answer.py
+++ b/livebench/gen_api_answer.py
@@ -87,6 +87,7 @@ def get_answer(
             messages.append({"role": "system", "content": question['system_prompt']})
 
         turns = []
+        reasoning_turns = []
         for j in range(len(question["turns"])):
             prompt = question["turns"][j]
             if model_config.prompt_prefix:
@@ -110,6 +111,10 @@ def get_answer(
                 m = None
 
             if m is not None:
+                # keep the thinking out of api_info; store it alongside turns instead
+                turn_reasoning = m.pop('reasoning_content', None)
+                if turn_reasoning:
+                    reasoning_turns.append(turn_reasoning)
                 turn_input_tokens = m.pop('input_tokens', None)
                 if turn_input_tokens is not None:
                     total_input_tokens += turn_input_tokens
@@ -122,7 +127,10 @@ def get_answer(
             turns.append(output)
             total_num_tokens += num_tokens
 
-        choices.append({"index": i, "turns": turns})
+        choice = {"index": i, "turns": turns}
+        if reasoning_turns:
+            choice["reasoning"] = reasoning_turns
+        choices.append(choice)
 
     cost_usd = None
     if getattr(model_config, 'cost_per_million', None):

--- a/livebench/model/completions.py
+++ b/livebench/model/completions.py
@@ -99,6 +99,11 @@ def chat_completion_openai(
         stream = actual_api_kwargs['stream']
         del actual_api_kwargs['stream']
 
+    # Thinking models return their chain of thought on a separate field, never in
+    # `content`. Without capturing it here the reasoning is generated, billed, and
+    # discarded — answer rows keep only the final visible text.
+    reasoning_text = ''
+
     try:
         if stream:
             stream: Stream[ChatCompletionChunk] = client.chat.completions.create(
@@ -117,6 +122,10 @@ def chat_completion_openai(
                 for chunk in stream:
                     if chunk.choices and len(chunk.choices) > 0 and chunk.choices[0].delta.content is not None:
                         message += chunk.choices[0].delta.content
+                    if chunk.choices and len(chunk.choices) > 0:
+                        _r = getattr(chunk.choices[0].delta, 'reasoning_content', None)
+                        if _r:
+                            reasoning_text += _r
                     if chunk.usage is not None:
                         num_tokens = chunk.usage.completion_tokens
                         if hasattr(chunk.usage, 'reasoning_tokens'):
@@ -144,6 +153,7 @@ def chat_completion_openai(
                 message = response.choices[0]
             else:
                 message = response.choices[0].message.content
+                reasoning_text = getattr(response.choices[0].message, 'reasoning_content', None) or ''
             input_tokens = None
             cached_tokens = None
             if response.usage is not None:
@@ -177,6 +187,10 @@ def chat_completion_openai(
             metadata = {'input_tokens': input_tokens}
             if cached_tokens is not None:
                 metadata['cached_tokens'] = cached_tokens
+
+        if reasoning_text:
+            metadata = metadata if metadata is not None else {}
+            metadata['reasoning_content'] = reasoning_text
 
         return output, num_tokens, metadata
     except Exception as e:
@@ -906,6 +920,18 @@ def chat_completion_litellm(
     token_exhaustion = False
     if response.usage is not None:
         num_tokens = response.usage.completion_tokens
+        # Thinking models bill reasoning as OUTPUT but report it OUTSIDE completion_tokens,
+        # under completion_tokens_details.reasoning_tokens. chat_completion_openai already
+        # folds it in (see the non-litellm path); this path did not, so every run made with
+        # --use-litellm under-counted output tokens -- and therefore cost -- by the whole
+        # reasoning trace. Measured on xAI: grok-4.5 completion=1015 + reasoning=1935,
+        # grok-4.6 completion=237 + reasoning=1901, i.e. a ~2-9x undercount depending on how
+        # verbose the visible answer is. Note usage.reasoning_tokens (top-level) is None for
+        # these providers, so only the details object is authoritative.
+        _ctd = getattr(response.usage, 'completion_tokens_details', None)
+        _reasoning = getattr(_ctd, 'reasoning_tokens', None) if _ctd is not None else None
+        if num_tokens is not None and _reasoning:
+            num_tokens += _reasoning
         input_tokens = response.usage.prompt_tokens
         cached_tokens = getattr(response.usage, 'cache_read_input_tokens', None) or 0
         if not cached_tokens and hasattr(response.usage, 'prompt_tokens_details') and response.usage.prompt_tokens_details is not None:
@@ -933,6 +959,10 @@ def chat_completion_litellm(
         if metadata is None:
             metadata = {}
         metadata['eval_status'] = 'token_exhaustion'
+
+    if reasoning_content:
+        metadata = metadata if metadata is not None else {}
+        metadata['reasoning_content'] = reasoning_content
 
     return message, num_tokens, metadata
 


### PR DESCRIPTION
Thinking tokens bill as OUTPUT but are reported OUTSIDE `completion_tokens`, under `completion_tokens_details.reasoning_tokens`. Two harness paths ignored them, so **recorded output tokens — and therefore cost — were understated by the entire reasoning trace**.

### What was wrong

| path | code | effect |
|---|---|---|
| regular | `completions.py` `chat_completion_litellm` | `num_tokens = usage.completion_tokens`, reasoning never added. `run_round.sh` always passes `--use-litellm`, so **every workflow run** was affected. |
| agentic | `litellm_model.py` | `output_tokens = res.usage.completion_tokens`; flows into trajectory `model_stats` -> `run_inference` `cost_usd` -> board cost columns. |

`chat_completion_openai` already folded reasoning in, which is why this went unnoticed.

### Measured on xAI

```
grok-4.5:  completion_tokens=1015  reasoning_tokens=1935
grok-4.6:  completion_tokens= 237  reasoning_tokens=1901
usage.reasoning_tokens (top-level) = None for both -> details object is the only source
```

So grok-4.5 and grok-4.6 reason by nearly identical amounts; 4.6 simply writes less visible prose. Pre-fix this looked like 4.6 being ~30x more token-efficient, which was an accounting artifact.

### Validated before/after on identical questions

```
question        PRE-fix   POST-fix   vis_chars
402e56855bea7b      125       1603        311
a357d967318937      181        976        578
c976648d528b54      198       2011        657
```

Visible output unchanged; the correction is the hidden reasoning. Harness smoke passes on both configs, and the corrected numbers also reveal `reasoning_effort` is a real knob (grok-4.6 out=2870 vs xhigh out=3346) where pre-fix it looked like a no-op.

### Also included

`reasoning_content` was extracted then discarded, so regular-task answer rows kept only the final visible text (a 31-char `<solution>` tag beside ~14k generated tokens). Now returned via metadata and stored on `choices[i].reasoning`, parallel to `turns`, leaving `api_info` untouched.

### Note on published data

Existing board cost columns for models reporting reasoning this way (including grok-4.5) are understated. That is pre-existing and not changed here, but worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)