### PR TITLE
configs: add deepseek-v4-pro-0813 (GA build, first-party endpoint)

### DIFF
--- a/livebench/model/model_configs/deepseek.yml
+++ b/livebench/model/model_configs/deepseek.yml
@@ -192,6 +192,32 @@ api_kwargs:
     temperature: 1
     max_tokens: 384000
 ---
+# DeepSeek V4 Pro, GA build 0813 (api-docs.deepseek.com lists model id `deepseek-v4-pro`
+# with "version: DeepSeek-V4-Pro-0813"). There is NO dated API slug -- neither first-party
+# nor Fireworks exposes deepseek-v4-pro-0813 -- so the id below is an UNPINNED alias and this
+# row corresponds to whatever build was live when it ran. The dated display_name records
+# which build that was; re-check the docs' version string before reusing these numbers.
+# Fireworks was deliberately NOT used: its deepseek-v4-pro may lag the first-party build.
+# Rates verified against api-docs.deepseek.com/quick_start/pricing on 2026-08-13:
+# 0.435 in / 0.003625 cache-hit / 0.87 out. The cached ratio is 0.0083x -- an order of
+# magnitude below flash's 0.020x, so do NOT copy rates between the two.
+# NOTE: DeepSeek's pricing page announces "a significant increase expected" in the near
+# future; these are the rates in effect at run time.
+display_name: deepseek-v4-pro-0813
+cost_per_million:
+  input: 0.435
+  cached_input: 0.003625
+  output: 0.87
+api_name:
+  https://api.deepseek.com: deepseek-v4-pro
+default_provider: https://api.deepseek.com
+api_keys:
+  https://api.deepseek.com: DEEPSEEK_API_KEY
+api_kwargs:
+  default:
+    temperature: 1
+    max_tokens: 384000
+---
 display_name: deepseek-v4-flash
 cost_per_million:
   input: 0.14


### PR DESCRIPTION
Adds a dated config entry for DeepSeek V4 Pro so a run is attributable to a specific build.

### Why a dated display_name when there is no dated slug

DeepSeek docs list **model id `deepseek-v4-pro`** with **`version: DeepSeek-V4-Pro-0813`**. Neither first-party nor Fireworks exposes a `deepseek-v4-pro-0813` slug (verified against both `/models` endpoints), so the id is an **unpinned alias** — if DeepSeek rolls it, the row silently stops corresponding to 0813. The dated `display_name` records which build a run actually used. Same idea as the existing `deepseek-v4-flash-0731-*` entries, except flash genuinely has a dated slug on Fireworks and pro does not.

### First-party, not Fireworks

Fireworks lists `deepseek-v4-pro` but may lag the GA build, so the first-party endpoint is authoritative for 0813.

### Rates

Verified at `api-docs.deepseek.com/quick_start/pricing` on 2026-08-13:

| | input | cache hit | output | cached ratio |
|---|---|---|---|---|
| deepseek-v4-pro | 0.435 | 0.003625 | 0.87 | **0.0083x** |
| deepseek-v4-flash | 0.14 | 0.0028 | 0.28 | 0.020x |

The cached ratio differs by an order of magnitude between the two, so rates must not be copied across. DeepSeek also announces `"a significant increase expected"` in pricing, so these are the rates in effect at run time.

### Existing entry untouched

`deepseek-v4-pro` keeps its config: it has a published board row and 28 data files that an in-place rename would orphan.

### Validation

- YAML parses, 19 configs, no duplicate `display_name`
- Harness smoke on the first-party endpoint: config resolves, API call OK, token tracking OK (in=129, out=2158 — reasoning tokens now counted post-#503), cost tracking OK, grading OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)