### PR TITLE
harness: enable native tool calling for first-party DeepSeek chat

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -892,6 +892,8 @@ class LitellmModel:
             return True
         if "qwen" in mn and self.config.api_type == "completion":               # Alibaba DashScope OpenAI-compat chat (tool_calls); tool_choice must be 'auto' (thinking mode)
             return True
+        if "deepseek" in mn and self.config.api_type == "completion":           # DeepSeek 1st-party chat (tool_calls); like qwen, tool_choice must be 'auto' -- 'required' 400s with "Thinking mode does not support this tool_choice"
+            return True
         if "inkling" in mn.lower() and self.config.api_type == "completion":     # Thinking Machines Inkling (Tinker OpenAI-compat chat, self-invoking tool_calls); same tool_calls path
             return True
         if self.config.native_gemini and 'gemini-3' in mn:                      # Gemini genai generate_content (function_call parts)


### PR DESCRIPTION
`_native_tools_enabled()` matched on family (`anthropic` / OpenAI-Responses / `grok` / `glm` / `kimi` / `qwen` / `inkling` / `gemini-3`) and had **no deepseek branch**, so first-party DeepSeek was offered no tools and fell back to regex-parsed ```bash fences — while `run_inference` already gave it the **native prompt template** via `_NO_FORCED_TOOL_CHOICE_HOSTS`. Native prompts with no tools to call is precisely the qwen failure mode.

### The endpoint supports it — probed directly

```
tool_choice=auto     -> tool_calls=1  {"name":"bash","arguments":{"command":"ls -la"}}  finish=tool_calls
tool_choice=required -> 400 "Thinking mode does not support this tool_choice"
```

So native works and must use `auto` — the same shape as qwen. `_native_tool_choice()` already returns `auto` for deepseek hosts, so no change is needed there; this is the one missing piece.

### Measured effect (deepseek-v4-pro-0813, same questions, same box)

| | prompt-based | native (this PR) |
|---|---|---|
| `native_tool_use_turns` | 0 | **== api_calls** |
| calls per question | 65–100, none finished at 12 min | **24–26** |
| completions in ~25 min | 0 (at 20 min) | **8/72** |

DeepSeek was burning turns re-deriving what one tool call does. This also removes most of its 250-step-cap risk — historically `deepseek-v4-flash-0731-fw` capped **22/72** and `deepseek-v4-flash` 3/72.

### Comparability note

New DeepSeek runs become comparable to `deepseek-v4-flash-0731-fw` (native, via the Fireworks Responses path) and **not** to the older prompt-based `deepseek-v4-flash` / `deepseek-v4-pro` rows. Worth being deliberate about when reading any before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)