### PR TITLE
config: add gemini-3.7-flash-high to google.yml

### DIFF
--- a/livebench/model/model_configs/google.yml
+++ b/livebench/model/model_configs/google.yml
@@ -400,6 +400,23 @@ api_kwargs:
     temperature: 1
     top_p: 0.95
 ---
+display_name: gemini-3.7-flash-high
+cost_per_million:
+  input: 0.75
+  cached_input: 0.075
+  output: 3.75
+api_name:
+  google: gemini-3.7-flash
+aliases:
+  - gemini-3.7-flash-high
+api_kwargs:
+  default:
+    thinking_config:
+      thinking_level: high
+    max_output_tokens: 65536
+    temperature: 1
+    top_p: 0.95
+---
 display_name: gemini-3-flash-preview-minimal
 api_name:
   google: gemini-3-flash-preview


### PR DESCRIPTION
Adds `gemini-3.7-flash-high` — identical settings to `gemini-3.6-flash-high` (thinking_level: high, max_output_tokens: 65536, temperature: 1, top_p: 0.95), API model ID `gemini-3.7-flash`.

Pricing is Google's introductory rate (through end of 2026), which is half of 3.6 flash:
- input: $0.75 / M
- cached_input: $0.075 / M
- output: $3.75 / M

Verified locally: config loads via `get_model_config('gemini-3.7-flash-high')` and a live API call to `gemini-3.7-flash` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)