### PR TITLE
config: add qwen3.8-27b via featherless.ai

### DIFF
--- a/livebench/model/model_configs/qwen.yml
+++ b/livebench/model/model_configs/qwen.yml
@@ -317,3 +317,39 @@ api_kwargs:
     stream: true
     extra_body:
       enable_thinking: true
+---
+# Qwen3.8-27B (dense 27B, vision-language, thinking ON by default) via featherless.ai —
+# first featherless entry. OpenAI-compatible chat endpoint, characterised 2026-08-17:
+#  * served at context 32768 / max_completion 32768 (native 262k) — the provider CLAMPS
+#    max_tokens to available context instead of 400ing (verified: 9k prompt + 32000 cap
+#    returned 200), so the full 32768 cap below is safe.
+#  * thinking arrives on a `reasoning` field (NOT `reasoning_content`), so the harness
+#    archives only the final `content` — answers are unaffected. Thinking is VERBOSE:
+#    a short-essay probe burned a 4000-token cap entirely on reasoning; never trim the cap.
+#  * native tool calling verified, tool_choice='required' accepted.
+#  * streaming verified incl. stream_options.include_usage
+#    (usage.prompt_tokens_details.cached_tokens present); ~73 tok/s.
+#  * concurrency is the real limit: featherless reserves 2 units/request for this model
+#    class; 40 concurrent (80 units) verified 429-free on the current key.
+display_name: qwen3.8-27b
+# Featherless bills flat-rate subscriptions (concurrency units, not tokens). The rates
+# below are the provider's own per-token listing from its API metadata
+# (https://api.featherless.ai/v1/models, verified 2026-08-17): $0.265 in / $0.65 out.
+# No published cache discount -> cached_input = full input rate (usage does report
+# cached_tokens, but no discounted rate exists to apply).
+cost_per_million:
+  input: 0.265
+  cached_input: 0.265
+  output: 0.65
+api_name:
+  https://api.featherless.ai/v1: Qwen/Qwen3.8-27B
+api_keys:
+  https://api.featherless.ai/v1: FEATHERLESS_API_KEY
+default_provider: https://api.featherless.ai/v1
+api_kwargs:
+  default:
+    # Qwen3.8 thinking-mode recommended sampling (model card): temp 1.0, top_p 0.95.
+    temperature: 1.0
+    top_p: 0.95
+    max_tokens: 32768
+    stream: true


### PR DESCRIPTION
Adds `qwen3.8-27b` (Qwen/Qwen3.8-27B, dense 27B VLM, thinking on by default) served by featherless.ai — the first featherless-backed entry.

Provider/model characterisation (2026-08-17, live probes against the endpoint):
- OpenAI-compatible chat endpoint at `https://api.featherless.ai/v1`, key env `FEATHERLESS_API_KEY`
- Served context 32768 / max_completion 32768; provider clamps max_tokens to available context (no 400), so the cap is set at the full 32768
- Native tool calling verified incl. `tool_choice='required'`; streaming verified incl. `stream_options.include_usage`; ~73 tok/s
- Reasoning arrives on a `reasoning` field (not `reasoning_content`); the final answer is in `content`
- Sampling per Qwen3.8 model card thinking-mode recommendation: temp 1.0 / top_p 0.95

Pricing: featherless bills flat-rate subscriptions (concurrency units, not tokens). `cost_per_million` uses the provider's own per-token listing from its `/v1/models` API metadata (verified 2026-08-17): $0.265 in / $0.65 out; no published cache discount, so `cached_input` = full input rate. Not intro pricing (no expiry to track).

Config gate (`config_gate.py --strict`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
