### PR TITLE
Add DeepSeek V4 Flash Vision (Exp) to live bench

### DIFF
--- a/livebench/model/model_configs/deepseek.yml
+++ b/livebench/model/model_configs/deepseek.yml
@@ -303,3 +303,26 @@ api_kwargs:
     max_output_tokens: 131072
     timeout: 3600
 preserve_reasoning: true
+---
+# DeepSeek V4 Flash Vision (Exp) — experimental multimodal variant of V4 Flash, released
+# 2026-08-21 (api-docs.deepseek.com/news/news260821). Matches V4 Flash on text/agents/
+# reasoning and adds image input (JPEG/PNG/GIF/WebP; billed as <=384 input tokens each).
+# First-party only: no US reseller (Fireworks/Novita) serves it as of 2026-08-22.
+# Rates from api-docs.deepseek.com/quick_start/pricing (2026-08-22): vision-exp bills at
+# V4-Flash rates. DeepSeek now bills peak/off-peak — the values below are OFF-PEAK
+# ($0.22 in / $0.007 cache-hit / $0.66 out); peak hours (01:00-04:00, 06:00-10:00 UTC) are 2x.
+# OpenRouter's flat $0.22/$0.66 matches off-peak.
+display_name: deepseek-v4-flash-vision-exp
+cost_per_million:
+  input: 0.22
+  cached_input: 0.007
+  output: 0.66
+api_name:
+  https://api.deepseek.com: deepseek-v4-flash-vision-exp
+default_provider: https://api.deepseek.com
+api_keys:
+  https://api.deepseek.com: DEEPSEEK_API_KEY
+api_kwargs:
+  default:
+    temperature: 1
+    max_tokens: 384000


### PR DESCRIPTION
Adds `deepseek-v4-flash-vision-exp` to `livebench/model/model_configs/deepseek.yml` (appended after the existing deepseek-v4-flash entries, mirroring their schema).

| Field | Value | Source |
|---|---|---|
| Model | DeepSeek-V4-Flash-Vision-Exp (experimental multimodal V4 Flash variant, released 2026-08-21) | https://api-docs.deepseek.com/news/news260821/ |
| Provider API ID | `deepseek-v4-flash-vision-exp` (DeepSeek first-party, `https://api.deepseek.com`) | https://api-docs.deepseek.com/quick_start/pricing |
| Context window | 1M tokens | https://api-docs.deepseek.com/quick_start/models |
| Max output | 384K tokens (`max_tokens: 384000`, matching the v4-flash entries) | https://api-docs.deepseek.com/quick_start/models |
| Input | text + image (JPEG/PNG/GIF/WebP; images billed as ≤384 input tokens each) | https://api-docs.deepseek.com/guides/vision/ |
| Pricing | Registered at official **off-peak** rates ($0.22 in / $0.007 cache-hit / $0.66 out per 1M); peak hours are 2x (noted in the entry comment). Cross-checked: OpenRouter's flat $0.22/$0.66 matches off-peak. | https://api-docs.deepseek.com/quick_start/pricing ; https://openrouter.ai/deepseek/deepseek-v4-flash-vision-exp |

No US reseller (Fireworks/Novita) serves the vision-exp variant as of 2026-08-22, so the entry is first-party-only, like `deepseek-v3.2*` above it. YAML parse-verified.