### PR TITLE
agentic: grade instances as they land (grader pool + eval cache)

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/run_inference.py
+++ b/livebench/agentic_code_runner/minisweagent/run_inference.py
@@ -1,5 +1,6 @@
 import json
 import os
+import threading
 import time
 import subprocess
 import shortuuid
@@ -35,6 +36,70 @@ def _eval_status_from_exit_status(exit_status):
         return "run_limits_exceeded"
     return "run_error"
 
+def _incremental_grading_loop(
+    questions: list[dict],
+    model_name: str,
+    all_traj_folder,
+    grading_parallel: int,
+    stop_event: threading.Event,
+    poll_seconds: int = 20,
+):
+    """Grader pool: grade agentic instances as they land instead of waiting for the
+    whole answer round. Polls the trajectory folder for newly written
+    <qid>.traj.json files and feeds each batch of completions through
+    agentic_coding_process_results, whose eval cache records the scores; the final
+    judgment pass then reuses them (hash-matched on the exact patch) instead of
+    re-running the docker evals. Failures here are safe: anything ungraded or
+    uncached is simply graded by the final pass as before.
+    """
+    questions_by_qid = {str(q['question_id']): q for q in questions}
+    handled: set[str] = set()
+    while True:
+        stopping = stop_event.is_set()
+        ready_questions, ready_answers = [], []
+        for qid, question in questions_by_qid.items():
+            if qid in handled:
+                continue
+            traj_file = all_traj_folder / qid / f"{qid}.traj.json"
+            if not traj_file.exists():
+                continue
+            try:
+                with open(traj_file) as f:
+                    trajectory = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                continue  # mid-write; the next poll picks it up
+            info = trajectory.get('info', {})
+            if _eval_status_from_exit_status(info.get('exit_status')) == 'run_error':
+                # infra failure — the collection pass writes $ERROR$ for it and
+                # --retry-failures re-runs it; nothing gradable here
+                handled.add(qid)
+                continue
+            # Same string the collection pass will put in choices[0].turns[0],
+            # so the cache's patch hash matches at judgment time.
+            submission = info.get('submission')
+            if submission is None:
+                submission = ""
+            ready_questions.append(question)
+            ready_answers.append({
+                'question_id': question['question_id'],
+                'model_id': model_name,
+                'choices': [{'turns': [submission]}],
+            })
+        if ready_questions:
+            print(f"incremental grader: grading {len(ready_questions)} completed instances "
+                  f"({len(handled) + len(ready_questions)}/{len(questions_by_qid)} handled)")
+            try:
+                agentic_coding_process_results(
+                    ready_questions, ready_answers, debug=False, max_workers=grading_parallel)
+            except Exception as e:
+                print(f"incremental grader: batch failed ({e}); the final grading pass will cover it")
+            handled.update(str(q['question_id']) for q in ready_questions)
+        if stopping:
+            break
+        stop_event.wait(timeout=poll_seconds)
+    print(f"incremental grader: done ({len(handled)}/{len(questions_by_qid)} instances handled)")
+
+
 def run_agentic_coding_inference(
     questions: list[dict],
     model_api_name: str,
@@ -49,6 +114,7 @@ def run_agentic_coding_inference(
     replay_traj_dir: str | None = None,
     custom_run_id: str | None = None,
     preserve_reasoning: bool | None = None,
+    grading_parallel: int = 0,
 ):
 
     if len(questions) == 0:
@@ -215,6 +281,21 @@ def run_agentic_coding_inference(
 
     print('Running command: ', ' '.join([str(c) for c in cmd]))
 
+    # Grader pool: grade instances as their trajectories land instead of leaving
+    # all docker evals to the judgment phase. Replay runs are excluded (their
+    # trajectories pre-exist, so everything would grade before the replay ran).
+    grader_stop = None
+    grader_thread = None
+    if grading_parallel > 0 and replay_traj_dir is None:
+        print(f"Incremental grading ON: grader pool of {grading_parallel} alongside the answer phase")
+        grader_stop = threading.Event()
+        grader_thread = threading.Thread(
+            target=_incremental_grading_loop,
+            args=(questions, model_name, all_traj_folder, grading_parallel, grader_stop),
+            daemon=True,
+        )
+        grader_thread.start()
+
     try:
         subprocess.run(cmd, check=True)
     except KeyboardInterrupt:
@@ -223,6 +304,10 @@ def run_agentic_coding_inference(
     except subprocess.CalledProcessError as e:
         print(f"Subprocess error: {e}")
         pass
+    finally:
+        if grader_thread is not None:
+            grader_stop.set()
+            grader_thread.join()
 
     for question in questions:
 

--- a/livebench/gen_api_answer.py
+++ b/livebench/gen_api_answer.py
@@ -244,6 +244,7 @@ def run_questions(
     model_display_name_override: str | None = None,
     api_dict: dict[str, str] | None = None,
     use_litellm: bool = False,
+    agentic_grading_parallel: int = 0,
 ):
     """
     Perform inference on a list of questions. Output answers to answer_file.
@@ -292,7 +293,8 @@ def run_questions(
                 model_display_name_override=model_display_name_override,
                 answer_file=answer_file,
                 parallel=parallel,
-                preserve_reasoning=model_config.preserve_reasoning
+                preserve_reasoning=model_config.preserve_reasoning,
+                grading_parallel=agentic_grading_parallel
             )
     
     # Process normal questions if any
@@ -404,6 +406,13 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--parallel", type=int, default=1, help="The number of concurrent API calls."
+    )
+    parser.add_argument(
+        "--agentic-grading-parallel", type=int, default=0,
+        help="If > 0, grade agentic coding instances incrementally as they complete, "
+             "using a grader pool of this many workers running alongside the answer "
+             "phase. Scores land in the agentic eval cache, which the judgment pass "
+             "reuses instead of re-running the docker evals. 0 disables (grade at the end)."
     )
     parser.add_argument(
         "--question-source",
@@ -546,7 +555,8 @@ if __name__ == "__main__":
                 use_litellm=args.use_litellm,
                 force_temperature=args.force_temperature,
                 model_provider_override=args.model_provider_override,
-                model_display_name_override=model_display_name
+                model_display_name_override=model_display_name,
+                agentic_grading_parallel=args.agentic_grading_parallel
             )
 
     elif args.question_source == "jsonl":
@@ -602,7 +612,8 @@ if __name__ == "__main__":
                 stream=args.stream,
                 use_litellm=args.use_litellm,
                 force_temperature=args.force_temperature,
-                model_provider_override=args.model_provider_override
+                model_provider_override=args.model_provider_override,
+                agentic_grading_parallel=args.agentic_grading_parallel
             )
 
     else:

--- a/livebench/process_results/coding/utils.py
+++ b/livebench/process_results/coding/utils.py
@@ -1,4 +1,8 @@
+import fcntl
+import hashlib
 import json
+import os
+import time
 from pathlib import Path
 from dataclasses import dataclass
 import pickle
@@ -259,7 +263,9 @@ def _run_evaluation_subprocess(
     """
     eval_id = shortuuid.uuid()
 
-    config_path = Path(LIVE_BENCH_ROOT_PATH / 'agentic_code_runner/eval/config.json')
+    # eval_id-scoped so concurrent evaluations (incremental grading during the answer
+    # phase, or two models on one box) don't clobber each other's config mid-run
+    config_path = Path(LIVE_BENCH_ROOT_PATH / f'agentic_code_runner/eval/config_{eval_id}.json')
     config_path.parent.mkdir(parents=True, exist_ok=True)
     model_name = answers[0]['model_id']
     patch_path = Path(LIVE_BENCH_ROOT_PATH / f'agentic_code_runner/data/patches/{model_name}_{eval_id}_patch.jsonl')
@@ -457,11 +463,150 @@ def _run_evaluation_subprocess(
     return result, instance_map
 
 
+# ---------------------------------------------------------------------------
+# Agentic eval cache: lets grading run incrementally while the answer phase is
+# still in flight (see run_inference._incremental_grading_loop). Every graded
+# question is recorded as one jsonl row keyed on a hash of the exact patch that
+# was graded; the final judgment pass then reuses those scores instead of
+# re-running the docker evals at round end. A changed patch (rerun, retry)
+# hash-misses and is re-evaluated, so the cache can never serve a stale score.
+# Disable entirely with LIVEBENCH_AGENTIC_EVAL_CACHE=0.
+# ---------------------------------------------------------------------------
+
+def _agentic_eval_cache_enabled() -> bool:
+    return os.environ.get('LIVEBENCH_AGENTIC_EVAL_CACHE', '1') != '0'
+
+
+def _agentic_eval_cache_path(model_id: str) -> Path:
+    return Path(LIVE_BENCH_ROOT_PATH / f"agentic_code_runner/data/eval_cache/{model_id.replace('/', '_')}.jsonl")
+
+
+def _agentic_patch_hash(fix_patch: str) -> str:
+    return hashlib.sha256((fix_patch or '').encode('utf-8', errors='replace')).hexdigest()
+
+
+def _load_agentic_eval_cache(model_id: str) -> dict[str, dict]:
+    path = _agentic_eval_cache_path(model_id)
+    if not path.exists():
+        return {}
+    rows: dict[str, dict] = {}
+    with open(path) as f:
+        fcntl.flock(f, fcntl.LOCK_SH)
+        try:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue  # torn write; the question just re-evaluates
+                rows[row['question_id']] = row  # append-only file: last write wins
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+    return rows
+
+
+def _append_agentic_eval_cache(model_id: str, rows: list[dict]) -> None:
+    if not rows:
+        return
+    path = _agentic_eval_cache_path(model_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, 'a') as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            for row in rows:
+                f.write(json.dumps(row) + '\n')
+            f.flush()
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+
+
 def agentic_coding_process_results(questions: list[dict], answers: list[dict], debug=False, max_workers=1, only_build_image=False) -> tuple[dict[str, int], dict[str, dict]]:
 
     if len(answers) == 0:
         return dict(), dict()
-    
+
+    model_id = answers[0]['model_id']
+    answers_by_qid = {a['question_id']: a for a in answers}
+    use_cache = _agentic_eval_cache_enabled() and not only_build_image
+
+    # Serve previously graded questions from the cache (hash of the graded patch
+    # must match the patch we're being asked to grade now).
+    cached: dict[str, dict] = {}
+    if use_cache:
+        cache = _load_agentic_eval_cache(model_id)
+        for question in questions:
+            qid = question['question_id']
+            answer = answers_by_qid.get(qid)
+            row = cache.get(qid)
+            if answer and row and row.get('patch_hash') == _agentic_patch_hash(answer['choices'][0]['turns'][0]):
+                cached[qid] = row
+        if cached:
+            print(f"agentic eval cache: reusing {len(cached)}/{len(questions)} graded questions for {model_id}")
+
+    todo_questions = [q for q in questions if q['question_id'] not in cached]
+    todo_answers = [a for a in answers if a['question_id'] not in cached]
+
+    result: dict[str, int] = {}
+    eval_metadata: dict[str, dict] = {}
+    if todo_questions:
+        result, instance_map = _evaluate_with_retries(todo_questions, todo_answers, debug, max_workers, only_build_image)
+
+        new_cache_rows = []
+        for q in todo_questions:
+            qid = q['question_id']
+            info = instance_map.get(qid, {})
+            meta = {
+                "eval_status": info.get("eval_status", "unknown"),
+                "eval_id": info.get("eval_id", ""),
+                "instance_id": info.get("instance_id", ""),
+            }
+            if info.get("error_msg"):
+                meta["error_msg"] = info["error_msg"]
+            if qid in answers_by_qid and "run_id" in answers_by_qid[qid]:
+                meta["run_id"] = answers_by_qid[qid]["run_id"]
+            eval_metadata[qid] = meta
+            # cache only questions that actually got a score; error/incomplete
+            # ones stay uncached so the next pass re-evaluates them
+            if use_cache and qid in result and qid in answers_by_qid:
+                row = {
+                    'question_id': qid,
+                    'model_id': model_id,
+                    'patch_hash': _agentic_patch_hash(answers_by_qid[qid]['choices'][0]['turns'][0]),
+                    'score': result[qid],
+                    'eval_status': meta['eval_status'],
+                    'eval_id': meta['eval_id'],
+                    'instance_id': meta['instance_id'],
+                    'tstamp': time.time(),
+                }
+                if 'error_msg' in meta:
+                    row['error_msg'] = meta['error_msg']
+                new_cache_rows.append(row)
+        if new_cache_rows:
+            _append_agentic_eval_cache(model_id, new_cache_rows)
+
+    # Merge cache hits back in (run_id comes from the CURRENT answer, not the cache)
+    for qid, row in cached.items():
+        result[qid] = row['score']
+        meta = {
+            "eval_status": row.get("eval_status", "unknown"),
+            "eval_id": row.get("eval_id", ""),
+            "instance_id": row.get("instance_id", ""),
+        }
+        if row.get("error_msg"):
+            meta["error_msg"] = row["error_msg"]
+        if qid in answers_by_qid and "run_id" in answers_by_qid[qid]:
+            meta["run_id"] = answers_by_qid[qid]["run_id"]
+        eval_metadata[qid] = meta
+
+    return result, eval_metadata
+
+
+def _evaluate_with_retries(questions: list[dict], answers: list[dict], debug=False, max_workers=1, only_build_image=False) -> tuple[dict[str, int], dict[str, dict]]:
+    """One full evaluation pass: initial run + the flaky-grading retry logic.
+    Returns (result: qid->score, instance_map: qid->eval metadata)."""
+
     # Initial evaluation
     result, instance_map = _run_evaluation_subprocess(questions, answers, debug, max_workers, only_build_image)
     
@@ -535,21 +680,5 @@ def agentic_coding_process_results(questions: list[dict], answers: list[dict], d
             
             # Update instance_map with new paths for next iteration
             instance_map.update(retry_instance_map)
-    
-    eval_metadata = {}
-    answers_by_qid = {a['question_id']: a for a in answers}
-    for q in questions:
-        qid = q['question_id']
-        info = instance_map.get(qid, {})
-        meta = {
-            "eval_status": info.get("eval_status", "unknown"),
-            "eval_id": info.get("eval_id", ""),
-            "instance_id": info.get("instance_id", ""),
-        }
-        if info.get("error_msg"):
-            meta["error_msg"] = info["error_msg"]
-        if qid in answers_by_qid and "run_id" in answers_by_qid[qid]:
-            meta["run_id"] = answers_by_qid[qid]["run_id"]
-        eval_metadata[qid] = meta
 
-    return result, eval_metadata
+    return result, instance_map

--- a/livebench/run_livebench.py
+++ b/livebench/run_livebench.py
@@ -273,6 +273,9 @@ def build_run_command(
         gen_api_cmd += f" --parallel {parallel_requests}"
     if parallel_grading:
         gen_judge_cmd += f" --parallel {parallel_grading}"
+        # grader pool: agentic instances are graded as they land during the answer
+        # phase (results cached; the judgment command above reuses them)
+        gen_api_cmd += f" --agentic-grading-parallel {parallel_grading}"
     # Handle resume flags
     if resume:
         gen_api_cmd += " --resume"


### PR DESCRIPTION
Agentic grading currently waits for the entire answer round even though each instance's trajectory lands the moment it finishes. This PR overlaps the two phases:

- **Grader pool** (`run_inference.py`): while `run_batch.py` answers, a watcher thread polls the trajectory folder and grades newly completed instances in batches via `agentic_coding_process_results` (`run_error` instances are skipped — no patch, and `--retry-failures` re-runs them). Pool size comes from the new `gen_api_answer.py --agentic-grading-parallel` flag; `run_livebench.py` wires it from `--parallel-grading`, so existing launch commands get the overlap for free.
- **Eval cache** (`process_results/coding/utils.py`): every graded question is appended to `agentic_code_runner/data/eval_cache/<model>.jsonl` keyed on a **sha256 of the exact patch graded**. The final judgment pass consults the cache and only re-runs hash misses — so the judgment phase becomes a fast harvest, while a changed patch (rerun, retry-failures round) always re-evaluates. `LIVEBENCH_AGENTIC_EVAL_CACHE=0` disables. flock-guarded read/append.
- **Failure-safe**: any watcher error just leaves questions uncached — the final pass grades them exactly as today. Replay runs never grade incrementally.
- Also: the eval harness config is now `config_<eval_id>.json` instead of a fixed shared path that concurrent evaluations clobbered.

Tested: cache round-trip (hit / patch-change miss / env-disable / only_build_image bypass, run_id refreshed from current answers), watcher loop against synthetic trajectories (grades as they land, skips run_error, drains stragglers on stop, correct pool size), `build_run_command` emits the flag, all touched modules compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)