### PR TITLE
agentic: surface native_tool_use_turns on the answer row

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/run_inference.py
+++ b/livebench/agentic_code_runner/minisweagent/run_inference.py
@@ -381,6 +381,9 @@ def run_agentic_coding_inference(
                 'total_cached_tokens': cached_tok,
                 'total_cache_creation_tokens': cache_creation_tok,
                 'n_model_calls': stats.get('api_calls'),
+                # surfaced top-level so consumers (finalize.sh's native_tools_effective,
+                # health scans) don't have to parse the embedded trajectory JSON
+                'native_tool_use_turns': stats.get('native_tool_use_turns'),
                 'total_time_s': stats.get('run_time_s'),
                 'model_cost': stats.get('instance_cost'),
                 'cost_usd': cost_usd,


### PR DESCRIPTION
`finalize.sh` computes `native_tools_effective` from the top-level `native_tool_use_turns` answer field, but `run_inference.py` only stored the count inside the embedded trajectory's `model_stats`, so every native run closed out mislabeled `native=false` (observed on today's deepseek-v4-flash-vision-exp run: 8022/8022 turns native, registry said false). Companion fix in livebench-private makes finalize fall back to parsing the trajectory for older rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)