### PR TITLE
Harness hardening: grading deps + CPU cap + live concurrency resize

### DIFF
--- a/livebench/gen_api_answer.py
+++ b/livebench/gen_api_answer.py
@@ -7,6 +7,7 @@ python3 gen_api_answer.py --model gpt-3.5-turbo
 import argparse
 import json
 import os
+import threading
 import time
 import concurrent.futures
 import glob
@@ -245,6 +246,7 @@ def run_questions(
     api_dict: dict[str, str] | None = None,
     use_litellm: bool = False,
     agentic_grading_parallel: int = 0,
+    parallel_control_file: str | None = None,
 ):
     """
     Perform inference on a list of questions. Output answers to answer_file.
@@ -318,11 +320,53 @@ def run_questions(
                     use_litellm=use_litellm,
                 )
         else:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=parallel) as executor:
+            # Live-resizable concurrency (opt-in): with --parallel-control-file, the
+            # pool is sized to a ceiling and gated by a semaphore whose capacity a
+            # watcher thread re-reads from the file every 10s — `echo 60 > <file>`
+            # rescales a running eval without losing in-flight requests. Without the
+            # flag this is a plain fixed pool, exactly as before.
+            gate = None
+            watch_stop = None
+            pool_size = parallel
+            if parallel_control_file:
+                pool_size = max(parallel * 8, 256)
+                gate = threading.Semaphore(parallel)
+                watch_stop = threading.Event()
+
+                def _watch_parallel_override(cur=parallel):
+                    while not watch_stop.is_set():
+                        try:
+                            v = int(open(parallel_control_file).read().strip())
+                        except (OSError, ValueError):
+                            v = None
+                        if v and 0 < v != cur:
+                            v = min(v, pool_size)
+                            print(f"parallel override: {cur} -> {v} (from {parallel_control_file})")
+                            if v > cur:
+                                for _ in range(v - cur):
+                                    gate.release()
+                            else:
+                                for _ in range(cur - v):
+                                    gate.acquire()  # takes effect as workers finish
+                            cur = v
+                        watch_stop.wait(10)
+
+                threading.Thread(target=_watch_parallel_override, daemon=True).start()
+
+            def _gated_get_answer(**kw):
+                if gate is not None:
+                    gate.acquire()
+                try:
+                    return get_answer(**kw)
+                finally:
+                    if gate is not None:
+                        gate.release()
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=pool_size) as executor:
                 futures = []
                 for question in normal_questions:
                     future = executor.submit(
-                        get_answer,
+                        _gated_get_answer,
                         question=question,
                         model_api_name=model_api_name,
                         provider=provider,
@@ -343,6 +387,8 @@ def run_questions(
                     concurrent.futures.as_completed(futures), total=len(futures)
                 ):
                     future.result()
+            if watch_stop is not None:
+                watch_stop.set()
     
     # Reorganize all answer files
     if len(questions) > 0:
@@ -406,6 +452,13 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--parallel", type=int, default=1, help="The number of concurrent API calls."
+    )
+    parser.add_argument(
+        "--parallel-control-file", type=str, default=None,
+        help="Path to a file the runner polls every 10s for a new concurrency value; "
+             "`echo 60 > <file>` rescales a RUNNING eval's regular-question parallelism "
+             "without losing in-flight requests (ceiling = max(8x initial, 256); the "
+             "agentic path is unaffected). Absent file = keep current value."
     )
     parser.add_argument(
         "--agentic-grading-parallel", type=int, default=0,
@@ -556,7 +609,8 @@ if __name__ == "__main__":
                 force_temperature=args.force_temperature,
                 model_provider_override=args.model_provider_override,
                 model_display_name_override=model_display_name,
-                agentic_grading_parallel=args.agentic_grading_parallel
+                agentic_grading_parallel=args.agentic_grading_parallel,
+                parallel_control_file=args.parallel_control_file
             )
 
     elif args.question_source == "jsonl":
@@ -613,7 +667,8 @@ if __name__ == "__main__":
                 use_litellm=args.use_litellm,
                 force_temperature=args.force_temperature,
                 model_provider_override=args.model_provider_override,
-                agentic_grading_parallel=args.agentic_grading_parallel
+                agentic_grading_parallel=args.agentic_grading_parallel,
+                parallel_control_file=args.parallel_control_file
             )
 
     else:

--- a/livebench/gen_ground_truth_judgment.py
+++ b/livebench/gen_ground_truth_judgment.py
@@ -623,6 +623,15 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    # Grading is CPU-bound (code execution, sympy equivalence, table compares) —
+    # parallelism beyond the core count starves workers past their timeout guards
+    # and records false zeros (measured 2026-08-22: integrals_with_game graded 37
+    # at parallel 100 on 32 cores vs its true 76; tablereformat 74.5 vs 98).
+    _cores = os.cpu_count() or args.parallel
+    if args.parallel > _cores:
+        print(f"capping --parallel {args.parallel} -> {_cores} (CPU-bound grading; more workers than cores causes spurious timeout zeros)")
+        args.parallel = _cores
+
     if args.livebench_release_option not in LIVE_BENCH_RELEASES:
         raise ValueError(f"Bad release {args.livebench_release_option}.")
 

--- a/livebench/run_livebench.py
+++ b/livebench/run_livebench.py
@@ -67,6 +67,7 @@ class LiveBenchParams:
     debug: bool = False
     model_provider_override: str | None = None
     only_incorrect: bool = False
+    parallel_control_file: str | None = None
 
     @classmethod
     def from_args(cls, args, model: str | None = None):
@@ -108,7 +109,8 @@ class LiveBenchParams:
             ignore_missing_answers=args.ignore_missing_answers,
             debug=args.debug,
             model_provider_override=args.model_provider_override,
-            only_incorrect=args.only_incorrect
+            only_incorrect=args.only_incorrect,
+            parallel_control_file=args.parallel_control_file
         )
 
 def run_command(cmd: str, env: dict[str, str] | None = None) -> int:
@@ -236,7 +238,8 @@ def build_run_command(
     ignore_missing_answers: bool = False,
     debug: bool = False,
     model_provider_override: str | None = None,
-    only_incorrect: bool = False
+    only_incorrect: bool = False,
+    parallel_control_file: str | None = None
 ) -> str:
     """Build the command to run gen_api_answer and gen_ground_truth_judgment in sequence"""
 
@@ -276,6 +279,8 @@ def build_run_command(
         # grader pool: agentic instances are graded as they land during the answer
         # phase (results cached; the judgment command above reuses them)
         gen_api_cmd += f" --agentic-grading-parallel {parallel_grading}"
+    if parallel_control_file:
+        gen_api_cmd += f" --parallel-control-file {parallel_control_file}"
     # Handle resume flags
     if resume:
         gen_api_cmd += " --resume"
@@ -363,6 +368,7 @@ def build_run_command_from_params(params: LiveBenchParams, bench_name: str | lis
         use_litellm=params.use_litellm,
         remove_existing_judgment_file=params.remove_existing_judgment_file,
         only_incorrect=params.only_incorrect,
+        parallel_control_file=params.parallel_control_file,
         ignore_missing_answers=params.ignore_missing_answers,
         debug=params.debug,
         model_provider_override=params.model_provider_override
@@ -515,6 +521,9 @@ def main():
     parser.add_argument("--debug", action="store_true",
                       help="Enable debug mode for gen_ground_truth_judgment.py (not passed to gen_api_answer.py)")
     parser.add_argument("--model-provider-override", help="Override the model provider for gen_api_answer.py")
+    parser.add_argument("--parallel-control-file", default=None,
+                      help="File polled by gen_api_answer every 10s for a new regular-question "
+                           "concurrency; `echo N > <file>` rescales a running eval live.")
 
     args = parser.parse_args()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,12 @@ dependencies = [
     "pandas", "requests", "rich>=10.0.0",
     "shortuuid", "sympy>=1.13", "tqdm>=4.62.1", "wheel", "tenacity", "lark", "latex2sympy2==1.9.1", "libtmux", "pyyaml", "dataclasses_json",
     "docker", "gitpython", "toml", "PyGithub", "unidiff", "ruamel.yaml", "simple-parsing", "rich-argparse", "pydantic_settings", "litellm", "tabulate", "textual>=1.0.0", "jinja2",
-    "typer", "platformdirs", "prompt_toolkit", "emoji", "syllapy", "unicodedata2", "spacy"
+    "typer", "platformdirs", "prompt_toolkit", "emoji", "syllapy", "unicodedata2", "spacy",
+    # grading-sandbox deps: the coding grader executes model solutions with THIS
+    # interpreter (reliability_guard pre-imports matplotlib; solutions commonly import
+    # scipy/sortedcontainers). A venv without these false-zeros the coding category
+    # (measured 2026-08-22: coding graded 39.6 in a minimal venv vs its true 68.2).
+    "matplotlib", "scipy", "sortedcontainers"
 ]
 
 [project.urls]


### PR DESCRIPTION
Three fixes/optimizations surfaced by the deepseek-v4-flash-vision-exp run (all bit in production; scores had to be corrected twice):

1. **Grading-sandbox deps declared** in pyproject (matplotlib, scipy, sortedcontainers): the coding grader executes model solutions with the install's own interpreter, and `reliability_guard` pre-imports matplotlib — a fresh minimal venv false-zeroed the entire coding category (graded 39.6 vs true 68.2).
2. **Judgment `--parallel` capped at core count**: grading is CPU-bound; at parallel 100 on 32 cores, sympy integral-equivalence and pandas table-compare graders starved past their timeout guards and recorded false zeros (integrals_with_game 37→true 76, tablereformat 74.5→98). Prints the cap when applied.
3. **`gen_api_answer --parallel-control-file`** (opt-in): a watcher polls the file every 10s and resizes a running eval's regular-question concurrency through a semaphore gate (`echo 60 > <file>`) — ceiling max(8x initial, 256), no in-flight requests lost, agentic path unaffected, exact legacy behavior when absent. `run_livebench --parallel-control-file` passes it through. Semaphore grow/shrink validated under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)