### PR TITLE
Add claude-melon-lp-eap (max effort) model config

### DIFF
--- a/livebench/model/completions.py
+++ b/livebench/model/completions.py
@@ -28,7 +28,7 @@ TIMEOUT = 1800
 # Models gated on 30-day retention (Fable/Mythos tier): the org-default
 # ANTHROPIC_API_KEY is ZDR and gets 400 model_not_available for them, so they
 # use the non-ZDR key instead. Substring-matched against the API model name.
-ANTHROPIC_SKIP_ZDR_MODELS = ('claude-fable-5',)
+ANTHROPIC_SKIP_ZDR_MODELS = ('claude-fable-5', 'claude-melon')
 
 
 def anthropic_api_key(model: str) -> str | None:

--- a/livebench/model/model_configs/anthropic.yml
+++ b/livebench/model/model_configs/anthropic.yml
@@ -746,6 +746,10 @@ aliases:
 api_kwargs:
   default:
     temperature: 1
+    # litellm path defaults to a 600s stream timeout, which kills+retries every
+    # max-effort generation longer than 10 min (fable-5 avoided this only because
+    # its `fallbacks` key routes it to the native client's 1800s timeout).
+    timeout: 1800
     extra_body:
       output_config:
         effort: max

--- a/livebench/model/model_configs/anthropic.yml
+++ b/livebench/model/model_configs/anthropic.yml
@@ -736,13 +736,14 @@ cost_per_million:
 # per the eval request. The server-side-fallback beta + opus-4-8 fallback present in
 # the fable-5 configs are deliberately OMITTED: a silent server-side fallback would mix
 # another model's answers into a new-model eval.
-display_name: claude-fable-5-1-beta-max-effort
+display_name: claude-fable-5-1-max-effort
 api_name:
   anthropic: claude-melon-lp-eap
 aliases:
   - claude-melon-lp-eap
   - claude-melon-lp-eap-max
-  - claude-fable-5-1-beta-max
+  - claude-fable-5-1-max
+  - claude-fable-5-1-beta-max-effort
 api_kwargs:
   default:
     temperature: 1

--- a/livebench/model/model_configs/anthropic.yml
+++ b/livebench/model/model_configs/anthropic.yml
@@ -726,3 +726,34 @@ cost_per_million:
   cached_input: 1.0
   cache_creation: 12.5
   output: 50.0
+---
+# claude-melon-lp-eap = Claude Fable 5.1 beta (Anthropic early-access API; no public
+# docs page yet — pricing per the Anthropic EAP arrangement relayed by the requesting
+# team, verified 2026-08-28): same rates as claude-fable-5 ($10 in / $12.50 cache write /
+# $50 out) except cache READS are 75% lower ($0.25/M vs $1.00/M). Re-verify against
+# https://docs.anthropic.com pricing when the model is published.
+# Effort ladder assumed identical to claude-fable-5 (same family); run at max effort
+# per the eval request. The server-side-fallback beta + opus-4-8 fallback present in
+# the fable-5 configs are deliberately OMITTED: a silent server-side fallback would mix
+# another model's answers into a new-model eval.
+display_name: claude-fable-5-1-beta-max-effort
+api_name:
+  anthropic: claude-melon-lp-eap
+aliases:
+  - claude-melon-lp-eap
+  - claude-melon-lp-eap-max
+  - claude-fable-5-1-beta-max
+api_kwargs:
+  default:
+    temperature: 1
+    extra_body:
+      output_config:
+        effort: max
+    thinking:
+      type: adaptive
+    max_tokens: 128000
+cost_per_million:
+  input: 10.0
+  cached_input: 0.25
+  cache_creation: 12.5
+  output: 50.0


### PR DESCRIPTION
Config for an early-access Anthropic model (`claude-melon-lp-eap`), max effort, same shape as the claude-fable-5 configs minus the server-side fallback (deliberate: a fallback would mix another model into a new-model eval). Pricing per the EAP arrangement (fable-5 rates, cache reads $0.25/M), verified 2026-08-28.

**Do not merge yet** — EAP model; keeping this as a PR until the model is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)