### PR TITLE
Fix litellm streaming connection-pool leak that wedges long runs

### DIFF
--- a/livebench/model/completions.py
+++ b/livebench/model/completions.py
@@ -784,13 +784,19 @@ def chat_completion_litellm(
     # multi-minute streams; force httpx (what the native SDK uses).
     litellm.disable_aiohttp_transport = True
     # Streamed error paths leak httpx pool slots (a stream that errors or times
-    # out untended never returns its connection to the pool); at the default
-    # ceiling the shared module_level_client eventually wedges every worker in
-    # httpcore wait_for_connection with zero sockets open. A large ceiling keeps
-    # the shared pool leak-tolerant for the lifetime of a full run.
+    # out untended never returns its connection to the pool); at httpx's default
+    # ceiling (max_connections=100) the shared module_level_client eventually
+    # wedges every worker in httpcore wait_for_connection with zero sockets open.
+    # HTTPHandler's `concurrent_limit` kwarg is IGNORED by litellm ("kept for
+    # backward compatibility"), so the ceiling must be raised by handing it an
+    # httpx.Client with explicit limits.
     if not getattr(litellm.module_level_client, '_livebench_pool_bumped', False):
         from litellm.llms.custom_httpx.http_handler import HTTPHandler
-        _big_pool_client = HTTPHandler(concurrent_limit=2000)
+        _big_pool_client = HTTPHandler(client=httpx.Client(
+            limits=httpx.Limits(max_connections=4000, max_keepalive_connections=100),
+            timeout=httpx.Timeout(timeout=TIMEOUT, connect=10.0),
+            follow_redirects=True,
+        ))
         _big_pool_client._livebench_pool_bumped = True  # type: ignore[attr-defined]
         litellm.module_level_client = _big_pool_client
 

--- a/livebench/model/completions.py
+++ b/livebench/model/completions.py
@@ -783,6 +783,16 @@ def chat_completion_litellm(
     # Anthropic long-stream reliability: litellm's default aiohttp transport drops
     # multi-minute streams; force httpx (what the native SDK uses).
     litellm.disable_aiohttp_transport = True
+    # Streamed error paths leak httpx pool slots (a stream that errors or times
+    # out untended never returns its connection to the pool); at the default
+    # ceiling the shared module_level_client eventually wedges every worker in
+    # httpcore wait_for_connection with zero sockets open. A large ceiling keeps
+    # the shared pool leak-tolerant for the lifetime of a full run.
+    if not getattr(litellm.module_level_client, '_livebench_pool_bumped', False):
+        from litellm.llms.custom_httpx.http_handler import HTTPHandler
+        _big_pool_client = HTTPHandler(concurrent_limit=2000)
+        _big_pool_client._livebench_pool_bumped = True  # type: ignore[attr-defined]
+        litellm.module_level_client = _big_pool_client
 
     api_kwargs: API_Kwargs = {
         'temperature': temperature

--- a/livebench/model/completions.py
+++ b/livebench/model/completions.py
@@ -889,23 +889,46 @@ def chat_completion_litellm(
     _MAX_ATTEMPTS = 3
 
     def _do_litellm_call(use_stream):
-        resp = litellm.completion(
-            model=litellm_model, messages=messages, stream=use_stream, timeout=timeout,
-            num_retries=3, **actual_api_kwargs
-        )
-        if use_stream:
-            # Consume the stream HERE so a mid-stream connection drop is caught and retryable.
-            chunks = list(resp)
-            last_usage = None
-            for chunk in reversed(chunks):
-                if hasattr(chunk, 'usage') and chunk.usage is not None:
-                    last_usage = chunk.usage
-                    break
-            resp = litellm.stream_chunk_builder(chunks, messages=messages)
-            if resp.usage is not None and last_usage is not None:
-                if not resp.usage.prompt_tokens and getattr(last_usage, 'prompt_tokens', None):
-                    resp.usage.prompt_tokens = last_usage.prompt_tokens
-        return resp
+        # Anthropic-routed calls get a PER-CALL httpx client: the shared sync pool
+        # deadlocks under concurrent stream closes — httpcore's PoolByteStream.close()
+        # takes the pool lock while litellm's "streaming-error-body-read" helper
+        # threads and connection-assignment events contend for it (observed as 99
+        # threads parked in connection_pool.handle_request + 22 in close during a
+        # 429 storm). A private client makes every close local to one call; the
+        # extra TLS handshake is noise next to minutes-long generations.
+        _call_client = None
+        _call_kwargs = actual_api_kwargs
+        if 'anthropic' in litellm_model and 'client' not in actual_api_kwargs:
+            from litellm.llms.custom_httpx.http_handler import HTTPHandler
+            _call_client = HTTPHandler(client=httpx.Client(
+                timeout=httpx.Timeout(timeout=TIMEOUT, connect=10.0),
+                follow_redirects=True,
+            ))
+            _call_kwargs = {**actual_api_kwargs, 'client': _call_client}
+        try:
+            resp = litellm.completion(
+                model=litellm_model, messages=messages, stream=use_stream, timeout=timeout,
+                num_retries=3, **_call_kwargs
+            )
+            if use_stream:
+                # Consume the stream HERE so a mid-stream connection drop is caught and retryable.
+                chunks = list(resp)
+                last_usage = None
+                for chunk in reversed(chunks):
+                    if hasattr(chunk, 'usage') and chunk.usage is not None:
+                        last_usage = chunk.usage
+                        break
+                resp = litellm.stream_chunk_builder(chunks, messages=messages)
+                if resp.usage is not None and last_usage is not None:
+                    if not resp.usage.prompt_tokens and getattr(last_usage, 'prompt_tokens', None):
+                        resp.usage.prompt_tokens = last_usage.prompt_tokens
+            return resp
+        finally:
+            if _call_client is not None:
+                try:
+                    _call_client.client.close()
+                except Exception:
+                    pass
 
     response = None
     for _attempt in range(1, _MAX_ATTEMPTS + 1):


### PR DESCRIPTION
Two related fixes for litellm streaming under high concurrency, both diagnosed with py-spy on a wedged 100-parallel run:

1. **Pool ceiling**: streamed error paths leak httpx pool slots; at httpx's default `max_connections=100` the shared `module_level_client` wedges every worker in httpcore `wait_for_connection` with zero sockets open. `HTTPHandler(concurrent_limit=…)` is ignored by litellm, so the ceiling is raised by passing an `httpx.Client` with explicit limits.
2. **Pool-lock deadlock**: under a 429 storm, concurrent stream closes deadlock the shared sync pool — `PoolByteStream.close()` takes the pool lock while litellm's `streaming-error-body-read` helper threads and connection-assignment events contend for it (observed: 99 threads in `handle_request`, 22 in `close`). Anthropic-routed calls now use a per-call client so every close is local; the extra TLS handshake is noise next to minutes-long generations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)