### PR TITLE
agentic: survive truncated tool-call JSON; explicit native-tools override

### DIFF
--- a/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
+++ b/livebench/agentic_code_runner/minisweagent/models/litellm_model.py
@@ -222,6 +222,12 @@ class LitellmModelConfig:
     model_kwargs: dict[str, Any] = field(default_factory=dict)
     litellm_model_registry: Path | str | None = os.getenv("LITELLM_MODEL_REGISTRY_PATH")
     preserve_reasoning: bool | None = None
+    # Explicit native-tools override for this run. None = infer from the model name
+    # (see _native_tools_enabled). Set from the LiveBench model config's
+    # agentic_native_tools key — name inference silently splits paired legs when a
+    # served alias lacks the family token (e.g. "r2e_step3" vs "qwen38-27b-base",
+    # 2026-08-30), so an eval that needs channel parity should set this explicitly.
+    native_tools: bool | None = None
     # gemini-3 uses the genai SDK by default; False routes it through litellm (the
     # replay keeps provider_specific_fields nested so thought signatures survive)
     native_gemini: bool = True
@@ -881,6 +887,9 @@ class LitellmModel:
         # graceful text-```bash fallback; native_tool_use_turns records actual adherence.
         if os.getenv("MSWEA_NATIVE_TOOLS", "1") != "1":
             return False
+        if self.config.native_tools is not None:
+            # explicit per-run setting wins over name inference (see config comment)
+            return self.config.native_tools
         mn = self.config.model_name
         if 'anthropic' in mn:                                                   # Anthropic direct SDK (tool_use)
             return True
@@ -942,6 +951,28 @@ class LitellmModel:
         if 'anthropic' not in self.config.model_name:
             for message in messages:
                 message.pop('provider_specific_fields', None)
+        # Replay net: a stored assistant turn can carry a tool_call whose arguments do
+        # not parse (length-truncated JSON from an older run or a path the append-time
+        # strip missed). Strict chat templates 400 on it forever. messages are fresh
+        # per-query dicts (see query()), so dropping in place is history-safe.
+        for message in messages:
+            _tcs = message.get('tool_calls')
+            if not _tcs:
+                continue
+            _good = []
+            for _tc in _tcs:
+                _fn = _tc.get('function') if isinstance(_tc, dict) else getattr(_tc, 'function', None)
+                _args = _fn.get('arguments') if isinstance(_fn, dict) else getattr(_fn, 'arguments', None)
+                try:
+                    json.loads(_args)
+                    _good.append(_tc)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+            if len(_good) != len(_tcs):
+                if _good:
+                    message['tool_calls'] = _good
+                else:
+                    message.pop('tool_calls', None)
         if 'deepseek' in self.config.model_name:
             for message in messages:
                 if message['role'] == 'system':
@@ -1023,15 +1054,30 @@ class LitellmModel:
         # ```bash block the text agent loop expects, and carry the raw command
         # out-of-band (result['tool_command']) for verbatim execution.
         tool_calls = getattr(res['choices'][0]['message'], 'tool_calls', None) or []
+        parseable_calls = []
         for tc in tool_calls:
             fn = getattr(tc, 'function', None)
-            if fn is not None and getattr(fn, 'name', '') == 'bash':
-                try:
-                    tool_command = json.loads(fn.arguments).get('command')
-                except (json.JSONDecodeError, TypeError, AttributeError):
-                    tool_command = None
-                if tool_command:
-                    break
+            try:
+                args = json.loads(fn.arguments) if fn is not None else None
+            except (json.JSONDecodeError, TypeError, AttributeError):
+                # Truncated emission (finish_reason=length mid-JSON). If this call is
+                # stored and replayed, strict chat templates reject every subsequent
+                # request ("Unterminated string ..."), killing the episode. Drop it.
+                continue
+            parseable_calls.append(tc)
+            if fn is not None and getattr(fn, 'name', '') == 'bash' and not tool_command:
+                tool_command = args.get('command') if isinstance(args, dict) else None
+        if len(parseable_calls) != len(tool_calls):
+            # keep only replay-safe calls on the stored message; None if nothing survives
+            try:
+                res['choices'][0]['message'].tool_calls = parseable_calls or None
+            except Exception:
+                logger.warning("could not strip malformed tool_calls from stored message")
+            if not tool_command:
+                content = (content or "") + (
+                    "\n\n[Your tool call was cut off by the output-token limit and has been"
+                    " discarded. Re-issue the command more concisely in your next turn.]"
+                )
         if tool_command and tool_command.strip():
             self.native_tool_use_turns += 1
             action_block = f"```bash\n{tool_command}\n```"

--- a/livebench/agentic_code_runner/minisweagent/run_inference.py
+++ b/livebench/agentic_code_runner/minisweagent/run_inference.py
@@ -142,6 +142,16 @@ def run_agentic_coding_inference(
     if preserve_reasoning:
         config['model']['preserve_reasoning'] = True
 
+    # Explicit native-tools override from the model config (agentic_native_tools key).
+    # Without it the channel is inferred from name substrings, which silently splits
+    # paired legs when a served alias lacks the family token (2026-08-30).
+    try:
+        _nt = getattr(get_model_config(model_name), 'agentic_native_tools', None)
+    except Exception:
+        _nt = None
+    if _nt is not None:
+        config['model']['native_tools'] = _nt
+
     config_path = all_traj_folder / 'config.yaml'
     with open(config_path, 'w') as f:
         yaml.dump(config, f)

--- a/livebench/model/api_model_config.py
+++ b/livebench/model/api_model_config.py
@@ -25,6 +25,7 @@ class ModelConfig:
     preserve_reasoning: bool | None = None # whether to preserve reasoning in multi-turn tasks
     cost_per_million: dict[str, float] | None = None # USD per 1M tokens; keys: input, cached_input, output
     api_base: str | None = None # explicit base URL for the provider (e.g. non-OpenAI Responses API endpoints like Meta)
+    agentic_native_tools: bool | None = None # agentic runs: force native tool-calling on/off; None = infer from model name (the inference substring-matches family tokens and silently splits paired legs when a served alias lacks one)
 
 @cache
 def load_model_configs(file_path: str) -> dict[str, ModelConfig]:


### PR DESCRIPTION
Two harness robustness fixes from a paired-eval postmortem (2026-08-29/30):

**1. Truncated tool-call JSON kills episodes permanently.** When a bash tool_call emission is cut by the output-token cap (finish_reason=length mid-JSON), the malformed call is stored in history and replayed on every subsequent request; strict chat templates (e.g. vLLM qwen3_xml) 400 with "Unterminated string..." forever — the episode is unrecoverable. Measured: 4/15 episodes of a qwen3.8-27b run died this way. Fix: strip unparseable tool_calls at append time (the model gets a note that its command was cut off and to re-issue concisely) plus a replay-time sanitizer that drops any stored tool_call whose arguments don't parse.

**2. Native-tools channel is inferred from model-name substrings.** `_native_tools_enabled()` matches family tokens ("qwen", "grok", ...) in the served model name. A checkpoint served under an alias without the token (e.g. `r2e_step3`, a LoRA of qwen3.8-27b) silently ran the tool-less text channel while its base-model comparison leg ran native — invalidating the pair. Fix: new optional `agentic_native_tools: true|false` key in the model config that overrides name inference; unset keeps today's behavior, so no existing config changes.

Both changes are no-ops for currently-passing runs: the strip only fires on JSON that would 400 anyway, and the override defaults to None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdmW3JWp24NCXQ3KVMEuar