### PR TITLE
Regular categories: grade-as-you-go alongside answer generation

### DIFF
--- a/livebench/gen_api_answer.py
+++ b/livebench/gen_api_answer.py
@@ -24,6 +24,7 @@ from livebench.common import (
     get_categories_tasks,
     load_questions,
     load_questions_jsonl,
+    load_test_cases_jsonl,
     LIVE_BENCH_DATA_SUPER_PATH,
     filter_questions,
     check_agentic_coding_requirements,
@@ -31,6 +32,8 @@ from livebench.common import (
 )
 
 from livebench.model import ModelConfig, get_model_config, get_api_function
+from livebench.incremental_judge import GradingPool, resolve_grading_workers
+from livebench.question_weights import regular_task_weight
 
 
 def get_answer(
@@ -179,6 +182,8 @@ def get_answer(
         with open(output_file, "a") as fout:
             fout.write(json.dumps(ans) + "\n")
 
+    return ans
+
 
 def setup_model(model_config: ModelConfig, api_dict: dict[str, str] | None = None, model_provider_override: str | None = None) -> tuple[str, APIKwargs | None, str, dict[str, str] | None]:
     
@@ -249,6 +254,8 @@ def run_questions(
     parallel_control_file: str | None = None,
     agentic_parallel: int | None = None,
     resume: bool = False,
+    grading_parallel: int = -1,
+    incremental_grading: bool = True,
 ):
     """
     Perform inference on a list of questions. Output answers to answer_file.
@@ -312,9 +319,26 @@ def run_questions(
     # Process normal questions if any
     if normal_questions:
         print(f'Processing {len(normal_questions)} standard questions')
+
+        # Longest-tasks-first: makespan is decided by when the slow tasks start,
+        # not by how fast the cheap ones finish (see question_weights.py).
+        normal_questions = sorted(normal_questions, key=regular_task_weight, reverse=True)
+
+        # Grade-as-you-go: each completed answer goes straight to a grading pool
+        # (CPU-capped; generation threads are network-bound so the budgets don't
+        # compete). The batch judgment pass remains the idempotent backstop.
+        grading_pool = None
+        grading_workers = resolve_grading_workers(grading_parallel)
+        if incremental_grading and grading_workers > 0:
+            judge_model_id = (model_display_name_override if model_display_name_override
+                              else model_config.display_name).lower()
+            grading_pool = GradingPool(judge_model_id, grading_workers)
+            print(f"Incremental grading ON: pool of {grading_workers} grading workers "
+                  "alongside answer generation")
+
         if parallel == 1:
             for question in tqdm.tqdm(normal_questions):
-                get_answer(
+                ans = get_answer(
                     question=question,
                     model_api_name=model_api_name,
                     provider=provider,
@@ -329,6 +353,8 @@ def run_questions(
                     model_config=model_config,
                     use_litellm=use_litellm,
                 )
+                if grading_pool is not None:
+                    grading_pool.submit(question, ans)
         else:
             # Live-resizable concurrency (opt-in): with --parallel-control-file, the
             # pool is sized to a ceiling and gated by a semaphore whose capacity a
@@ -367,10 +393,13 @@ def run_questions(
                 if gate is not None:
                     gate.acquire()
                 try:
-                    return get_answer(**kw)
+                    ans = get_answer(**kw)
                 finally:
                     if gate is not None:
                         gate.release()
+                if grading_pool is not None:
+                    grading_pool.submit(kw['question'], ans)
+                return ans
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=pool_size) as executor:
                 futures = []
@@ -399,7 +428,10 @@ def run_questions(
                     future.result()
             if watch_stop is not None:
                 watch_stop.set()
-    
+
+        if grading_pool is not None:
+            grading_pool.drain_and_close()
+
     # Reorganize all answer files
     if len(questions) > 0:
         # Collect unique answer files from questions
@@ -477,6 +509,19 @@ if __name__ == "__main__":
              "Scores land in the agentic eval cache, which the judgment pass reuses "
              "instead of re-running the docker evals. Default -1 = auto "
              "(min(8, cpu_count)); 0 disables (grade everything at the end)."
+    )
+    parser.add_argument(
+        "--grading-parallel", type=int, default=-1,
+        help="Workers for grading regular-category answers as they are generated "
+             "(grade-as-you-go). Grading is CPU-bound, so the value is capped at "
+             "cpu_count. Default -1 = auto (min(cpu_count, 16)); 0 disables."
+    )
+    parser.add_argument(
+        "--no-incremental-grading",
+        action="store_true",
+        default=False,
+        help="Do not grade regular-category answers as they are generated; leave all "
+             "grading to the gen_ground_truth_judgment pass."
     )
     parser.add_argument(
         "--no-traj-harvest",
@@ -612,13 +657,18 @@ if __name__ == "__main__":
                     )
 
                     questions = filter_questions(questions, answer_file, args.resume, args.retry_failures)
-                    
+
                     # Attach answer_file to each question and task info for agentic_coding
                     for question in questions:
                         question['answer_file'] = answer_file
-                    
+                        # destination for grade-as-you-go judgments (same per-task
+                        # path the judgment pass writes to)
+                        question['_judgment_file'] = (
+                            f"data/{task_full_name}/model_judgment/ground_truth_judgment.jsonl"
+                        )
+
                     all_questions.extend(questions)
-                    
+
                     print(f"Questions from {task_full_name}")
         
         if all_questions:
@@ -639,7 +689,9 @@ if __name__ == "__main__":
                 agentic_grading_parallel=args.agentic_grading_parallel,
                 parallel_control_file=args.parallel_control_file,
                 agentic_parallel=args.agentic_parallel,
-                resume=args.resume and not args.no_traj_harvest
+                resume=args.resume and not args.no_traj_harvest,
+                grading_parallel=args.grading_parallel,
+                incremental_grading=not args.no_incremental_grading
             )
 
     elif args.question_source == "jsonl":
@@ -664,17 +716,23 @@ if __name__ == "__main__":
                 questions = load_questions_jsonl(
                     question_file, release_set, args.livebench_release_option, args.question_id
                 )
-                
+                # inline LCB/coding grading needs the test cases attached (the
+                # judgment pass loads them the same way)
+                questions = load_test_cases_jsonl(question_file, questions)
+
                 questions = questions[args.question_begin:args.question_end]
 
                 bench_name_for_file = os.path.dirname(question_file).replace("data/", "")
                 answer_file = f"data/{bench_name_for_file}/model_answer/{model_display_name.lower()}.jsonl"
 
                 questions = filter_questions(questions, answer_file, args.resume, args.retry_failures)
-                
+
                 # Attach answer_file to each question and task info for agentic_coding
                 for question in questions:
                     question['answer_file'] = answer_file
+                    question['_judgment_file'] = (
+                        f"data/{bench_name_for_file}/model_judgment/ground_truth_judgment.jsonl"
+                    )
                 
                 all_questions.extend(questions)
                         
@@ -699,7 +757,9 @@ if __name__ == "__main__":
                 agentic_grading_parallel=args.agentic_grading_parallel,
                 parallel_control_file=args.parallel_control_file,
                 agentic_parallel=args.agentic_parallel,
-                resume=args.resume and not args.no_traj_harvest
+                resume=args.resume and not args.no_traj_harvest,
+                grading_parallel=args.grading_parallel,
+                incremental_grading=not args.no_incremental_grading
             )
 
     else:

--- a/livebench/incremental_judge.py
+++ b/livebench/incremental_judge.py
@@ -1,0 +1,127 @@
+"""Grade-as-you-go for the regular (non-agentic) categories.
+
+GradingPool grades each answer right after gen_api_answer produces it, instead
+of leaving all grading to the gen_ground_truth_judgment pass at the end. Each
+work item carries its own (question, answer) pair — no qid-keyed lookup — so
+question_id collisions across tasks cannot mispair (see the _answer_key fix in
+the batch path). The batch judgment pass stays the idempotent backstop: run it
+with --resume and it grades only what this pool didn't (keyed on answer_id).
+
+Two lanes:
+- a CPU-capped thread pool for normal graders (sympy, table compares, puzzles);
+  grading is CPU-bound, and more workers than cores causes spurious timeout
+  zeros (measured: integrals_with_game 37 vs true 76 at parallel 100 on 32
+  cores), so the cap is a correctness guard, not a tuning knob;
+- a single-worker lane for LCB-style code-execution tasks (coding_completion /
+  LCB_generation), which fork test-runner subprocesses with wall-clock timeouts
+  and historically required serial execution — the dedicated lane keeps them
+  serial with respect to each other without serializing everything else the way
+  the batch pass does.
+
+Failure policy: anything that cannot be graded inline is simply left for the
+backstop pass — a row is only written by play_a_match_gt itself, so a crash
+here never writes a wrong judgment that --resume would then skip.
+"""
+
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+# Tasks whose grading forks test-runner subprocesses; kept serial (see module doc).
+SERIAL_GRADING_TASKS = {"coding_completion", "LCB_generation"}
+
+# Mirrors play_a_match_gt's coding_test_case_tasks: these carry test cases
+# instead of a ground_truth field.
+_CODING_TEST_CASE_TASKS = {
+    "coding_completion", "LCB_generation", "code_generation", "code_completion",
+    "agentic_coding",
+}
+
+# Old-format instruction_following (graded batch-only, per-task, in the backstop
+# pass); the boundary date matches gen_ground_truth_judgment.
+_OLD_IF_BOUNDARY = "2025-11-25"
+
+
+def resolve_grading_workers(requested: int | None) -> int:
+    """-1/None = auto (CPU-capped); 0 = disabled; N = min(N, cpu_count)."""
+    cores = os.cpu_count() or 8
+    if requested is None or requested < 0:
+        return min(cores, 16)
+    return min(requested, cores)
+
+
+class GradingPool:
+    def __init__(self, model_id: str, workers: int, debug: bool = False):
+        self.model_id = model_id
+        self.debug = debug
+        self._normal = ThreadPoolExecutor(max_workers=max(workers, 1),
+                                          thread_name_prefix="grade")
+        self._serial = ThreadPoolExecutor(max_workers=1, thread_name_prefix="grade-lcb")
+        self._lock = threading.Lock()
+        self._futures = []
+        self._judgment_files: set[str] = set()
+        self.graded = 0
+        self.errors = 0
+        self.skipped = 0
+
+    def _route(self, question: dict) -> str | None:
+        """Return 'serial'/'normal', or None to leave the answer to the backstop pass."""
+        from livebench.common import AGENTIC_CODING_CATEGORIES
+        category = question.get("category")
+        task = question.get("task")
+        if category in AGENTIC_CODING_CATEGORIES:
+            return None  # own incremental pipeline in run_inference
+        if category == "instruction_following" and \
+                question.get("livebench_release_date", "") < _OLD_IF_BOUNDARY:
+            return None  # old-format IF is graded per-task in batch only
+        if (task not in _CODING_TEST_CASE_TASKS and category != "instruction_following"
+                and "ground_truth" not in question):
+            return None  # play_a_match_gt would raise; leave to the backstop
+        if not question.get("_judgment_file"):
+            return None
+        return "serial" if task in SERIAL_GRADING_TASKS else "normal"
+
+    def _grade(self, question: dict, answer: dict) -> None:
+        from livebench.common import MatchSingle
+        from livebench.gen_ground_truth_judgment import play_a_match_gt
+        try:
+            play_a_match_gt(
+                MatchSingle(dict(question), self.model_id, answer),
+                output_file=question["_judgment_file"],
+                debug=self.debug,
+            )
+            with self._lock:
+                self.graded += 1
+        except Exception as e:
+            with self._lock:
+                self.errors += 1
+            print(f"incremental judge: grading failed for {question.get('question_id')} "
+                  f"({type(e).__name__}: {e}); the judgment sweep will cover it")
+
+    def submit(self, question: dict, answer: dict | None) -> bool:
+        """Queue one freshly generated answer for grading; False = left to the backstop."""
+        if answer is None:
+            return False
+        lane = self._route(question)
+        if lane is None:
+            with self._lock:
+                self.skipped += 1
+            return False
+        self._judgment_files.add(question["_judgment_file"])
+        executor = self._serial if lane == "serial" else self._normal
+        self._futures.append(executor.submit(self._grade, question, answer))
+        return True
+
+    def drain_and_close(self) -> tuple[int, int, int]:
+        """Wait for queued grading to finish, tidy the judgment files, report counts."""
+        self._normal.shutdown(wait=True)
+        self._serial.shutdown(wait=True)
+        from livebench.gen_ground_truth_judgment import reorg_output_file
+        for f in self._judgment_files:
+            try:
+                reorg_output_file(f)
+            except OSError as e:
+                print(f"incremental judge: could not reorg {f}: {e}")
+        print(f"incremental judge: done ({self.graded} graded inline, {self.errors} "
+              f"failed, {self.skipped} left to the judgment sweep)")
+        return self.graded, self.errors, self.skipped

--- a/livebench/run_livebench.py
+++ b/livebench/run_livebench.py
@@ -64,6 +64,7 @@ class LiveBenchParams:
     stream: bool = False
     use_litellm: bool = False
     remove_existing_judgment_file: bool = False
+    no_incremental_grading: bool = False
     ignore_missing_answers: bool = False
     debug: bool = False
     model_provider_override: str | None = None
@@ -108,6 +109,7 @@ class LiveBenchParams:
             stream=args.stream,
             use_litellm=args.use_litellm,
             remove_existing_judgment_file=args.remove_existing_judgment_file,
+            no_incremental_grading=args.no_incremental_grading,
             ignore_missing_answers=args.ignore_missing_answers,
             debug=args.debug,
             model_provider_override=args.model_provider_override,
@@ -238,6 +240,7 @@ def build_run_command(
     stream: bool = False,
     use_litellm: bool = False,
     remove_existing_judgment_file: bool = False,
+    no_incremental_grading: bool = False,
     ignore_missing_answers: bool = False,
     debug: bool = False,
     model_provider_override: str | None = None,
@@ -323,6 +326,16 @@ def build_run_command(
         gen_api_cmd += " --use-litellm"
     if remove_existing_judgment_file:
         gen_judge_cmd += " --remove-existing-file"
+    if no_incremental_grading:
+        gen_api_cmd += " --no-incremental-grading"
+    elif parallel_grading:
+        # grade-as-you-go workers for the regular categories (gen_api_answer caps
+        # the value at cpu_count itself)
+        gen_api_cmd += f" --grading-parallel {parallel_grading}"
+    if not no_incremental_grading and not remove_existing_judgment_file and not resume and not resume_grading:
+        # inline grading already wrote most judgments; make the trailing judgment
+        # pass a resume sweep over whatever it missed instead of a full re-grade
+        gen_judge_cmd += " --resume"
     if ignore_missing_answers:
         gen_judge_cmd += " --ignore-missing-answers"
     if model_provider_override:
@@ -374,6 +387,7 @@ def build_run_command_from_params(params: LiveBenchParams, bench_name: str | lis
         stream=params.stream,
         use_litellm=params.use_litellm,
         remove_existing_judgment_file=params.remove_existing_judgment_file,
+        no_incremental_grading=params.no_incremental_grading,
         only_incorrect=params.only_incorrect,
         parallel_control_file=params.parallel_control_file,
         ignore_missing_answers=params.ignore_missing_answers,
@@ -505,6 +519,9 @@ def main():
     parser.add_argument("--max-tokens", type=int, help="Maximum tokens for model responses")
     parser.add_argument("--parallel-requests", type=int, help="Number of parallel requests for API calls")
     parser.add_argument("--parallel-grading", type=int, help="Number of parallel grading threads")
+    parser.add_argument("--no-incremental-grading", action="store_true", default=False,
+                        help="Disable grade-as-you-go for the regular categories; all grading "
+                             "happens in the trailing gen_ground_truth_judgment pass.")
     parser.add_argument("--agentic-parallel-requests", type=int, default=None,
                         help="Concurrent docker containers for agentic coding questions, as a "
                              "budget separate from --parallel-requests (API concurrency). "


### PR DESCRIPTION
Part 2/3 (stacked on #526).

- New incremental_judge.GradingPool: each answer graded right after generation via play_a_match_gt with its own (question, answer) pair — no qid-keyed lookup, so cross-task question_id collisions can't mispair. Two lanes: CPU-capped pool for normal graders + a 1-worker serial lane for LCB/coding_completion. Anything ungradable inline is left to the trailing judgment pass (idempotent via answer_id).
- gen_api_answer: --grading-parallel (-1 auto = min(cpus,16)) / --no-incremental-grading; normal questions run longest-tasks-first; jsonl source loads test cases so inline LCB grading works.
- run_livebench turns the trailing judgment pass into a --resume sweep when inline grading is on.

Verified: 16 replayed answers across AMPS_Hard, consecutive_events, integrals_with_game (collision pair), paraphrase_3, LCB_generation grade identically to the current batch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SD6F7ghbbmaCWDaBFsD1u