### PR TITLE
One process drives agentic + regular lanes concurrently; decoupled budgets

### DIFF
--- a/livebench/gen_api_answer.py
+++ b/livebench/gen_api_answer.py
@@ -281,7 +281,12 @@ def run_questions(
     agentic_coding_questions = [q for q in questions if q.get('category') in AGENTIC_CODING_CATEGORIES]
     normal_questions = [q for q in questions if q.get('category') not in AGENTIC_CODING_CATEGORIES]
     
-    # Process agentic coding questions if any
+    # Process agentic coding questions if any. When regular questions are also
+    # present, the agentic run happens on a side thread so both lanes proceed
+    # concurrently (containers vs API requests are separate budgets) — one
+    # process replaces the old two-tmux-session workaround.
+    agentic_thread = None
+    agentic_error: list[BaseException] = []
     if agentic_coding_questions:
         if not check_agentic_coding_requirements():
             print("Warning: litellm or docker missing, skipping agentic coding evaluation")
@@ -300,22 +305,36 @@ def run_questions(
             effective_agentic_parallel = agentic_parallel
             if effective_agentic_parallel is None:
                 effective_agentic_parallel = parallel if not normal_questions else min(parallel, 15)
-            run_agentic_coding_inference(
-                questions=agentic_coding_questions,
-                model_api_name=model_api_name,
-                provider=provider,
-                force_temperature=force_temperature,
-                num_choices=num_choices,
-                model_api_kwargs=agentic_api_kwargs,
-                api_dict=api_dict,
-                model_display_name_override=model_display_name_override,
-                answer_file=answer_file,
-                parallel=effective_agentic_parallel,
-                preserve_reasoning=model_config.preserve_reasoning,
-                grading_parallel=agentic_grading_parallel,
-                resume=resume,
-            )
-    
+
+            def _run_agentic():
+                try:
+                    run_agentic_coding_inference(
+                        questions=agentic_coding_questions,
+                        model_api_name=model_api_name,
+                        provider=provider,
+                        force_temperature=force_temperature,
+                        num_choices=num_choices,
+                        model_api_kwargs=agentic_api_kwargs,
+                        api_dict=api_dict,
+                        model_display_name_override=model_display_name_override,
+                        answer_file=answer_file,
+                        parallel=effective_agentic_parallel,
+                        preserve_reasoning=model_config.preserve_reasoning,
+                        grading_parallel=agentic_grading_parallel,
+                        resume=resume,
+                    )
+                except BaseException as e:
+                    agentic_error.append(e)
+                    print(f"agentic lane failed: {type(e).__name__}: {e}")
+
+            if normal_questions:
+                agentic_thread = threading.Thread(target=_run_agentic, name="agentic-lane")
+                agentic_thread.start()
+            else:
+                _run_agentic()
+                if agentic_error:
+                    raise agentic_error[0]
+
     # Process normal questions if any
     if normal_questions:
         print(f'Processing {len(normal_questions)} standard questions')
@@ -432,6 +451,12 @@ def run_questions(
         if grading_pool is not None:
             grading_pool.drain_and_close()
 
+    # Wait for the agentic lane before tidying files
+    if agentic_thread is not None:
+        if agentic_thread.is_alive():
+            print("Regular questions done; waiting for the agentic lane to finish")
+        agentic_thread.join()
+
     # Reorganize all answer files
     if len(questions) > 0:
         # Collect unique answer files from questions
@@ -449,6 +474,9 @@ def run_questions(
         # Reorganize each unique answer file
         for file in answer_files_to_reorg:
             reorg_answer_file(file)
+
+    if agentic_error:
+        raise agentic_error[0]
 
 
 if __name__ == "__main__":

--- a/livebench/run_livebench.py
+++ b/livebench/run_livebench.py
@@ -398,6 +398,11 @@ def build_run_command_from_params(params: LiveBenchParams, bench_name: str | lis
 def run_model(params: LiveBenchParams) -> None:
     """Run livebench for a single model"""
     if params.mode == "parallel":
+        print("WARNING: --mode parallel (one tmux pane per category) is deprecated. "
+              "The shared-pool single/sequential modes supersede it: one process, one "
+              "true concurrency cap, grade-as-you-go, and no idle tail when short "
+              "categories drain. Per-pane processes also each pay the model/config "
+              "setup and disable cross-category scheduling.")
         run_parallel(params)
     elif params.mode == "sequential":
         run_sequential(params)

--- a/livebench/run_livebench.py
+++ b/livebench/run_livebench.py
@@ -49,6 +49,7 @@ class LiveBenchParams:
     parallel_requests: int | None = None
     parallel_grading: int | None = None
     agentic_parallel_requests: int | None = None
+    agentic_grading_parallel: int | None = None
     resume: bool = False
     resume_inference: bool = False
     resume_grading: bool = False
@@ -94,6 +95,7 @@ class LiveBenchParams:
             parallel_requests=args.parallel_requests,
             parallel_grading=args.parallel_grading,
             agentic_parallel_requests=args.agentic_parallel_requests,
+            agentic_grading_parallel=args.agentic_grading_parallel,
             resume=args.resume,
             resume_inference=args.resume_inference,
             resume_grading=args.resume_grading,
@@ -225,6 +227,7 @@ def build_run_command(
     parallel_requests: int | None = None,
     parallel_grading: int | None = None,
     agentic_parallel_requests: int | None = None,
+    agentic_grading_parallel: int | None = None,
     resume: bool = False,
     resume_inference: bool = False,
     resume_grading: bool = False,
@@ -282,12 +285,18 @@ def build_run_command(
         gen_api_cmd += f" --parallel {parallel_requests}"
     if agentic_parallel_requests:
         gen_api_cmd += f" --agentic-parallel {agentic_parallel_requests}"
+    if agentic_grading_parallel is not None:
+        # explicit agentic grading-container budget, decoupled from the (CPU-bound)
+        # regular grading parallelism — essential for combined regular+agentic runs
+        # where parallel_grading can be 10x what docker grading should run at
+        gen_api_cmd += f" --agentic-grading-parallel {agentic_grading_parallel}"
     if parallel_grading:
         gen_judge_cmd += f" --parallel {parallel_grading}"
         # grader pool: agentic instances are graded as they land during the answer
         # phase (results cached; the judgment command above reuses them). Without
         # --parallel-grading, gen_api_answer's own auto default still enables it.
-        gen_api_cmd += f" --agentic-grading-parallel {parallel_grading}"
+        if agentic_grading_parallel is None:
+            gen_api_cmd += f" --agentic-grading-parallel {parallel_grading}"
     if parallel_control_file:
         gen_api_cmd += f" --parallel-control-file {parallel_control_file}"
     # Handle resume flags
@@ -372,6 +381,7 @@ def build_run_command_from_params(params: LiveBenchParams, bench_name: str | lis
         parallel_requests=params.parallel_requests,
         parallel_grading=params.parallel_grading,
         agentic_parallel_requests=params.agentic_parallel_requests,
+        agentic_grading_parallel=params.agentic_grading_parallel,
         resume=params.resume,
         resume_inference=params.resume_inference,
         resume_grading=params.resume_grading,
@@ -524,6 +534,10 @@ def main():
     parser.add_argument("--max-tokens", type=int, help="Maximum tokens for model responses")
     parser.add_argument("--parallel-requests", type=int, help="Number of parallel requests for API calls")
     parser.add_argument("--parallel-grading", type=int, help="Number of parallel grading threads")
+    parser.add_argument("--agentic-grading-parallel", type=int, default=None,
+                        help="Grading-container budget for incremental agentic grading, decoupled "
+                             "from --parallel-grading (which is CPU-bound regular grading). "
+                             "Default: follows --parallel-grading, else gen_api_answer's auto.")
     parser.add_argument("--no-incremental-grading", action="store_true", default=False,
                         help="Disable grade-as-you-go for the regular categories; all grading "
                              "happens in the trailing gen_ground_truth_judgment pass.")


### PR DESCRIPTION
Part 3/3 (stacked on the grade-as-you-go PR).

- run_questions starts the agentic run on a side thread when regular questions are present: one invocation drives containers and API requests under separate budgets, retiring the two-tmux-session workaround.
- --mode parallel (six per-category panes) prints a deprecation warning but keeps working.
- --agentic-grading-parallel on run_livebench decouples the docker grading-container budget from the (CPU-bound) regular grading parallelism — essential for combined runs where --parallel-grading can be 64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SD6F7ghbbmaCWDaBFsD1u