### PR TITLE
Add gpt-6-astra-max config

### DIFF
--- a/livebench/model/model_configs/openai.yml
+++ b/livebench/model/model_configs/openai.yml
@@ -1620,3 +1620,26 @@ api_kwargs:
     reasoning:
       effort: max
       summary: auto
+---
+# Published OpenAI rates (https://developers.openai.com/api/docs/pricing, verified 2026-09-04):
+#   gpt-6-astra standard: $10 in / $1 cached / $12.50 cache write / $50 out = 0.1x cached
+#   Long-context tier (>272K input tokens): $20 / $2 / $25 / $75 — NOT modelled here.
+#   Batch/Flex 0.5x, Fast mode 2x (not used). No intro-pricing expiry noted.
+#   Model card (https://developers.openai.com/api/docs/models/gpt-6-astra): context 1,050,000,
+#   max input 922,000, max output 128,000; reasoning effort low/medium/high/xhigh/max;
+#   knowledge cutoff 2026-04-30; rolling out first to Trusted Access Program orgs.
+display_name: gpt-6-astra-max
+cost_per_million:
+  input: 10
+  cached_input: 1
+  output: 50
+api_name:
+  openai_responses: gpt-6-astra
+api_kwargs:
+  default:
+    temperature: null
+    max_completion_tokens: 128000
+    timeout: 1800
+    reasoning:
+      effort: max
+      summary: auto


### PR DESCRIPTION
Adds `gpt-6-astra-max` — OpenAI GPT-6 Astra (`gpt-6-astra`, Responses API), effort `max`, same shape as the `gpt-5.6-*-max` entries.

**Pricing (verified 2026-09-04, https://developers.openai.com/api/docs/pricing):** $10 in / $1 cached / $12.50 cache write / $50 out per M (0.1x cached). Long-context tier above 272K input tokens is $20 / $2 / $25 / $75 and is **not modelled** by `cost_per_million` (LiveBench prompts stay far below it). Batch/Flex 0.5x and Fast mode 2x are not used.

**Model card (https://developers.openai.com/api/docs/models/gpt-6-astra):** context 1,050,000; max input 922,000; max output 128,000 → explicit `max_completion_tokens: 128000` so the config gate sees a real ceiling. Effort ladder low/medium/high/xhigh/max. Knowledge cutoff 2026-04-30.

Note: OpenAI says Astra is rolling out first to Trusted Access Program orgs — access on our key is probed before launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtZH3PiJtSejMjSrNn9CwF