### PR TITLE
coding sandbox: budget RLIMIT_AS/DATA on top of the inherited address space (fixes in-process coding false zeros)

### DIFF
--- a/livebench/code_runner/eval/utils.py
+++ b/livebench/code_runner/eval/utils.py
@@ -274,6 +274,19 @@ class redirect_stdin(contextlib._RedirectStream):  # type: ignore
     _stream = "stdin"
 
 
+def _current_vm_kb(field: str) -> int:
+    """Current value of a /proc/self/status memory field (VmSize / VmData) in kB;
+    0 where /proc is unavailable (macOS), which leaves the limits unchanged."""
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith(field + ":"):
+                    return int(line.split()[1])
+    except (OSError, ValueError, IndexError):
+        pass
+    return 0
+
+
 def reliability_guard(max_as_limit, max_data_limit, max_stack_limit):
     """
     This disables various destructive functions and prevents the generated code
@@ -304,6 +317,22 @@ def reliability_guard(max_as_limit, max_data_limit, max_stack_limit):
         max_as_limit = max_as_limit * 1024 * 1024
         max_data_limit = max_data_limit * 1024 * 1024
         max_stack_limit = max_stack_limit * 1024 * 1024
+
+        # The limits are a budget for the GRADED code, so they must sit on top of
+        # whatever address space this process already inherited. unsafe_execute
+        # runs in a fork of the caller; when the caller is the eval process
+        # (incremental grading during answer generation: hundreds of pool threads
+        # and their glibc arenas), the child starts out above 30 GB of virtual
+        # memory. A limit BELOW current usage makes every later mmap fail with
+        # ENOMEM — the very next line, `import matplotlib`, dies with "failed to
+        # map segment from shared object" — and every execution-graded coding
+        # answer scores 0 while all other signals look clean (118/118 false
+        # zeros on 2026-09-02, 117/117 on 2026-09-04; a standalone judgment
+        # process, forked from a small parent, graded the same answers
+        # correctly). RLIMIT_DATA counts private anonymous mappings too since
+        # Linux 4.7, so it gets the same treatment.
+        max_as_limit += _current_vm_kb("VmSize") * 1024
+        max_data_limit += _current_vm_kb("VmData") * 1024
 
         if platform.uname().system != "Darwin":
             resource.setrlimit(


### PR DESCRIPTION
## The bug
`reliability_guard` sets `RLIMIT_AS` / `RLIMIT_DATA` to an **absolute** 30 GB and then imports matplotlib. `unsafe_execute` runs in a `multiprocessing.Process` **fork** of the caller. During incremental grading the caller is the eval process itself — hundreds of `ThreadPoolExecutor` threads plus their glibc arenas — whose virtual size is already above 30 GB. Setting a limit *below* current usage succeeds, but every subsequent `mmap` fails with ENOMEM, so the very next line dies:

```
ImportError: .../matplotlib/_c_internal_utils.cpython-311-x86_64-linux-gnu.so: failed to map segment from shared object
```

Result: **every execution-graded coding answer scores 0** while every other signal (answers, tokens, judgments count) looks clean. Hit 118/118 on muse-spark-1.3 (2026-09-02) and 117/117 on gpt-6-astra (2026-09-04); both were rescued by a zeros-only regrade in a standalone `gen_ground_truth_judgment.py` process, which forks from a small parent and grades the same answers correctly. It very likely also explains the gemini-3.8-flash coding zeros attributed to "CPU starvation".

## The fix
Add the process's current `VmSize` / `VmData` (read from `/proc/self/status`) to the configured limits, so they stay a *budget for the graded code* regardless of who forked the sandbox. Small parent: +~20 MB, i.e. unchanged in practice. macOS (`/proc` absent): limits unchanged.

## Verification
Repro script inflates the parent's address space with `PROT_NONE|MAP_NORESERVE` mappings (no RSS, no overcommit), then calls the real `untrusted_check` on a trivial matplotlib+numpy solution:

| parent VmSize | before | after |
|---|---|---|
| 21 MB | `pass` | `pass` |
| 36 GB | `timeout` (scored 0) | `pass` |
| 60 GB | — | `pass` |

The LCB grader (`lcb_runner/evaluation/testing_util.py`) calls its own guard with `maximum_memory_bytes=None` (no rlimit) and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtZH3PiJtSejMjSrNn9CwF